### PR TITLE
feat: add --insecure flag to skip TLS certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Go implementation of CERN SSO authentication tools. This is the Go equivalent 
 - Get OIDC access tokens via Authorization Code flow
 - Device Authorization Grant flow for headless environments
 - Cookie reuse: Existing auth.cern.ch cookies are reused for new CERN subdomains, avoiding redundant Kerberos authentication
+- Support for skipping certificate validation via `--insecure`
 
 ## Installation
 
@@ -166,6 +167,7 @@ Use `--json` flag for machine-readable output:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--quiet` or `-q` | `false` | Suppress all output (except critical errors). Exit code 0 on success, non-zero otherwise. |
+| `--insecure` or `-k` | `false` | Skip certificate validation (insecure) |
 | `--user` or `-u` | (none) | Use specific CERN.CH Kerberos principal (e.g., `clange` or `clange@CERN.CH`). See [Multiple Kerberos Credentials](#multiple-kerberos-credentials). |
 | `--krb5-config` | `embedded` | Kerberos config source: `embedded` (built-in CERN.CH config), `system` (uses `/etc/krb5.conf` or `KRB5_CONFIG` env var), or a file path |
 
@@ -177,6 +179,7 @@ Use `--json` flag for machine-readable output:
 | `--file` | `cookies.txt` | Output cookie file |
 | `--auth-host` | `auth.cern.ch` | Keycloak hostname |
 | `--force` | `false` | Force refresh of cookies, bypassing validation |
+| `--insecure` | `false` | Skip certificate validation |
 
 ### Token Command
 
@@ -194,6 +197,7 @@ Use `--json` flag for machine-readable output:
 | `--client-id` | (required) | OAuth client ID |
 | `--auth-host` | `auth.cern.ch` | Keycloak hostname |
 | `--realm` | `cern` | Keycloak realm |
+| `--insecure` | `false` | Skip certificate validation |
 
 ### Status Command
 
@@ -201,6 +205,7 @@ Use `--json` flag for machine-readable output:
 |------|---------|-------------|
 | `--file` | `cookies.txt` | Cookie file to check |
 | `--json` | `false` | Output as JSON instead of table format |
+| `--insecure` | `false` | Skip certificate validation |
 
 ## Requirements
 
@@ -225,6 +230,7 @@ This tool is a Go port of the [auth-get-sso-cookie](https://gitlab.cern.ch/authz
 |---------|--------|-----|
 | Dependencies | requests, beautifulsoup4, requests-gssapi | None (single binary) |
 | Kerberos | System GSS-API | Built-in (gokrb5) |
+| Insecure | Supported (`verify=verify_cert`) | Supported (`--insecure`) |
 | QR Codes | Supported | Not yet |
 
 ## Testing

--- a/pkg/auth/kerberos_test.go
+++ b/pkg/auth/kerberos_test.go
@@ -104,7 +104,7 @@ func TestTryLoginWithCookies_NoCookies(t *testing.T) {
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
-	kc, _ := newKerberosClientFromKrbClient(cl, "test")
+	kc, _ := newKerberosClientFromKrbClient(cl, "test", true)
 
 	result, err := kc.TryLoginWithCookies("https://example.com", "auth.example.com", nil)
 
@@ -125,7 +125,7 @@ func TestTryLoginWithCookies_InvalidRedirect(t *testing.T) {
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
-	kc, _ := newKerberosClientFromKrbClient(cl, "test")
+	kc, _ := newKerberosClientFromKrbClient(cl, "test", true)
 
 	// Create a mock server that redirects to auth (simulating invalid cookies)
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -153,7 +153,7 @@ func TestTryLoginWithCookies_Success(t *testing.T) {
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
-	kc, _ := newKerberosClientFromKrbClient(cl, "test")
+	kc, _ := newKerberosClientFromKrbClient(cl, "test", true)
 
 	// Create a mock server that returns success (valid cookies)
 	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -189,7 +189,7 @@ func TestTryLoginWithCookies_VerifiesCookiesSent(t *testing.T) {
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
-	kc, _ := newKerberosClientFromKrbClient(cl, "test")
+	kc, _ := newKerberosClientFromKrbClient(cl, "test", true)
 
 	// Create a mock server that verifies cookies are received
 	cookiesReceived := make([]string, 0)
@@ -249,7 +249,7 @@ func TestTryLoginWithCookies_DomainFixing(t *testing.T) {
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
-	kc, _ := newKerberosClientFromKrbClient(cl, "test")
+	kc, _ := newKerberosClientFromKrbClient(cl, "test", true)
 
 	// Create a mock server
 	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cookie/jar.go
+++ b/pkg/cookie/jar.go
@@ -2,6 +2,7 @@ package cookie
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
@@ -50,7 +51,7 @@ func FilterAuthCookies(cookies []*http.Cookie, authHost string) []*http.Cookie {
 
 // VerifyCookies checks if cookies are valid for the target URL.
 // Returns (valid, remainingDuration) tuple.
-func VerifyCookies(targetURL, authHost string, cookies []*http.Cookie) (bool, time.Duration) {
+func VerifyCookies(targetURL, authHost string, cookies []*http.Cookie, verifyCert bool) (bool, time.Duration) {
 	u, err := url.Parse(targetURL)
 	if err != nil {
 		return false, 0
@@ -74,6 +75,9 @@ func VerifyCookies(targetURL, authHost string, cookies []*http.Cookie) (bool, ti
 
 	client := &http.Client{
 		Jar: jar,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyCert},
+		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Host == authHost {
 				return http.ErrUseLastResponse


### PR DESCRIPTION
Implement global `--insecure` and `-k` flags to allow skipping TLS certificate verification, matching the original Python tool's behaviour.

- Update pkg/auth:
  - Modify NewKerberosClient and NewKerberosClientWithUser to accept verifyCert boolean.
  - Configure http.Transport with InsecureSkipVerify based on the flag.
  - Update OIDC flows in oidc.go to respect the VerifyCert setting.
- Update pkg/cookie:
  - Modify VerifyCookies to support the verifyCert option.
- Update main.go:
  - Add flags to all relevant subcommands (cookie, token, device, status).
  - Propagate the flag value from CLI to authentication and cookie verification functions.
- Update Tests:
  - Update unit tests in pkg/auth/kerberos_test.go and pkg/cookie/jar_test.go.
  - Update integration_test.go and improve TestIntegration_InvalidCredentials robustness.
- Documentation:
  - Update README.md with detailed information on the new flag across all commands.

Fixes #7 