### PR TITLE
refactor: extract NormalizePrincipal helper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,9 +4,9 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
+	"github.com/clelange/cern-sso-cli/pkg/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -95,16 +95,7 @@ func formatDuration(d time.Duration) string {
 }
 
 // normalizeUsername ensures the username has @CERN.CH suffix with correct case.
+// This is a convenience wrapper around auth.NormalizePrincipal.
 func normalizeUsername(username string) string {
-	if username == "" {
-		return ""
-	}
-	if !strings.Contains(username, "@") {
-		username = username + "@CERN.CH"
-	}
-	if strings.HasSuffix(strings.ToLower(username), "@cern.ch") {
-		parts := strings.Split(username, "@")
-		username = parts[0] + "@CERN.CH"
-	}
-	return username
+	return auth.NormalizePrincipal(username)
 }

--- a/pkg/auth/ccache_test.go
+++ b/pkg/auth/ccache_test.go
@@ -101,3 +101,26 @@ func TestConvertAPICacheToFile_WithFileCache(t *testing.T) {
 		t.Errorf("Expected 'not using macOS API cache' error, got: %v", err)
 	}
 }
+
+func TestNormalizePrincipal(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"alice", "alice@CERN.CH"},
+		{"alice@CERN.CH", "alice@CERN.CH"},
+		{"alice@cern.ch", "alice@CERN.CH"},
+		{"BOB@cern.ch", "BOB@CERN.CH"},
+		{"bob", "bob@CERN.CH"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := NormalizePrincipal(tc.input)
+			if result != tc.expected {
+				t.Errorf("NormalizePrincipal(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/auth/kerberos.go
+++ b/pkg/auth/kerberos.go
@@ -227,13 +227,7 @@ func NewKerberosClientWithUser(version string, krb5ConfigSource string, krbUsern
 	}
 
 	// Normalize username for storage
-	if !strings.Contains(username, "@") {
-		username = username + "@CERN.CH"
-	}
-	if strings.HasSuffix(strings.ToLower(username), "@cern.ch") {
-		parts := strings.Split(username, "@")
-		username = parts[0] + "@CERN.CH"
-	}
+	username = NormalizePrincipal(username)
 	return newKerberosClientFromKrbClientWithUser(cl, version, verifyCert, username)
 }
 


### PR DESCRIPTION
- Extract NormalizePrincipal() to pkg/auth to eliminate code duplication
- Add unit test for NormalizePrincipal