### PR TITLE
refactor(cookie): use encoding/json for JSON status output

### DIFF
--- a/pkg/cookie/status_test.go
+++ b/pkg/cookie/status_test.go
@@ -420,7 +420,7 @@ func TestPrintStatusJSON_EmptyCookies(t *testing.T) {
 
 	output := buf.String()
 
-	if output != "[\n]\n" {
-		t.Errorf("Expected empty JSON array with newlines, got: %q", output)
+	if output != "[]\n" {
+		t.Errorf("Expected empty JSON array, got: %q", output)
 	}
 }


### PR DESCRIPTION
Replace manual JSON string formatting in printStatusJSON() with proper encoding/json marshaling. This change:

- Adds CookieStatusJSON struct with proper json tags
- Uses json.NewEncoder with SetIndent for formatted output
- Handles null expires field correctly via pointer type
- Improves maintainability and eliminates escaping issues

Updated TestPrintStatusJSON_EmptyCookies to match new encoder output.