### PR TITLE
feat: add container image with embedded CERN CA certificates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Git
+.git
+.gitignore
+
+# GitHub
+.github/
+
+# Build artifacts
+dist/
+cern-sso-cli
+
+# Test artifacts
+cookies.txt
+*_test.go
+integration_test.go
+
+# Documentation (not needed in image)
+README.md
+LICENSE
+
+# IDE
+.vscode/
+.idea/
+
+# Environment
+.envrc
+
+# OS
+.DS_Store
+
+# Gemini artifacts
+.gemini/

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,61 @@
+name: Container
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default: latest)'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ jobs:
           go-version: '1.25'
           cache: true
 
+      - name: Install certificate tools
+        run: sudo apt-get update && sudo apt-get install -y curl openssl
+
+      - name: Download CERN CA certificates
+        run: make download-certs
+
       - name: Build all platforms
         run: make build-all VERSION=${{ github.event.release.tag_name }}
 
@@ -25,3 +31,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Install dependencies
       run: go mod download
 
+    - name: Download CERN CA certificates
+      run: make download-certs
+
     - name: Run Unit Tests
       run: make test
 
@@ -39,6 +42,9 @@ jobs:
       with:
         go-version: '1.25'
         cache: true
+
+    - name: Download CERN CA certificates
+      run: make download-certs
 
     - name: Install Kerberos tools
       run: |
@@ -120,6 +126,9 @@ jobs:
     - name: Install dependencies
       run: go mod download
 
+    - name: Download CERN CA certificates
+      run: make download-certs
+
     - name: Run Integration Tests
       if: env.KRB_USERNAME != '' && env.KRB_PASSWORD != ''
       env:
@@ -137,6 +146,7 @@ jobs:
         go-version: '1.25'
         cache: true
     - run: go mod download
+    - run: make download-certs
     - run: make test
     - run: make build
 
@@ -154,10 +164,14 @@ jobs:
         go-version: '1.25'
         cache: true
 
+    - name: Download CERN CA certificates
+      run: make download-certs
+
     - name: Configure Kerberos
       run: |
         sudo tee /etc/krb5.conf << 'EOF'
         [libdefaults]
+
             default_realm = CERN.CH
             dns_lookup_realm = false
             dns_lookup_kdc = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,32 +1,19 @@
-# Binaries
-cern-sso-cli
+# Build output
 dist/
+cern-sso-cli
 
-# Environment variables
+# Test artifacts
+cookies.txt
+
+# IDE
+.vscode/
+.idea/
+
+# Environment
 .envrc
-.env
-
-# Cookies and test output
-*.txt
-!requirements.txt
-
-# Go
-view.sh
-*.out
-*.test
-*.prof
-
-# Python
-.venv/
-__pycache__/
-*.py[cod]
-*$py.class
 
 # OS
 .DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
+
+# Downloaded CERN CA certificates (downloaded at build time, not stored in git)
+pkg/auth/certs/*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache curl openssl git make
+
+WORKDIR /app
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Download CERN CA certificates and build
+RUN make download-certs
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')" -o cern-sso-cli .
+
+# Runtime stage
+FROM alpine:latest
+
+# Install runtime dependencies
+# ca-certificates: for TLS connections
+# krb5: Kerberos tools (kinit, klist) for credential cache support
+RUN apk add --no-cache ca-certificates krb5
+
+# Copy the binary
+COPY --from=builder /app/cern-sso-cli /usr/local/bin/cern-sso-cli
+
+# Set default KRB5CCNAME so users only need to mount the file
+ENV KRB5CCNAME=/tmp/krb5cc
+
+# Set entrypoint
+ENTRYPOINT ["cern-sso-cli"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 BINARY_NAME=cern-sso-cli
 # Get version from git tag, or fallback to short hash + dirty flag
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# Container image name (override with IMAGE_NAME=ghcr.io/user/repo make docker-build)
+IMAGE_NAME ?= cern-sso-cli
 
-.PHONY: all build clean test-integration build-all
+.PHONY: all build clean test-integration build-all download-certs docker-build docker-push
 
 all: build
 
@@ -18,9 +20,14 @@ test:
 clean:
 	rm -f $(BINARY_NAME)
 	rm -rf dist/
+	rm -f pkg/auth/certs/*.pem
+
+# Download CERN CA certificates for embedding
+download-certs:
+	./scripts/download_certs.sh
 
 # Cross-platform builds
-build-all: build-darwin-amd64 build-darwin-arm64 build-linux-amd64 build-linux-arm64
+build-all: download-certs build-darwin-amd64 build-darwin-arm64 build-linux-amd64 build-linux-arm64
 
 build-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o dist/$(BINARY_NAME)-darwin-amd64 .
@@ -33,4 +40,12 @@ build-linux-amd64:
 
 build-linux-arm64:
 	GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o dist/$(BINARY_NAME)-linux-arm64 .
+
+# Docker targets
+docker-build:
+	docker build -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
+
+docker-push:
+	docker push $(IMAGE_NAME):$(VERSION)
+	docker push $(IMAGE_NAME):latest
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ go install github.com/clelange/cern-sso-cli@latest
 ```bash
 git clone https://github.com/clelange/cern-sso-cli.git
 cd cern-sso-cli
+make download-certs  # Downloads CERN CA certificates
 make build
 ```
 
@@ -36,6 +37,37 @@ make build-all
 ```
 
 Binaries will be placed in the `dist/` directory.
+
+### Container Image
+
+Multi-architecture container images (amd64/arm64) are available from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/clelange/cern-sso-cli:latest
+```
+
+Run with a Kerberos credential cache:
+
+```bash
+# Linux (file-based cache) - mount your ticket to /tmp/krb5cc
+docker run --rm \
+  -v /tmp/krb5cc_$(id -u):/tmp/krb5cc \
+  -v $(pwd):/output \
+  ghcr.io/clelange/cern-sso-cli cookie --url https://gitlab.cern.ch --file /output/cookies.txt
+
+# With password authentication
+docker run --rm \
+  -e KRB_USERNAME=your-username \
+  -e KRB_PASSWORD=your-password \
+  -v $(pwd):/output \
+  ghcr.io/clelange/cern-sso-cli cookie --url https://gitlab.cern.ch --file /output/cookies.txt
+```
+
+Build locally:
+
+```bash
+make docker-build
+```
 
 ## Usage
 

--- a/pkg/auth/certs/certs.go
+++ b/pkg/auth/certs/certs.go
@@ -1,0 +1,73 @@
+// Package certs provides embedded CERN CA certificates.
+// Certificates are downloaded at build time by scripts/download_certs.sh
+// and embedded into the binary using go:embed.
+package certs
+
+import (
+	"crypto/x509"
+	_ "embed"
+	"fmt"
+)
+
+// CERN CA certificate files (downloaded at build time)
+//
+//go:embed cern_root_ca2.pem
+var cernRootCA2 []byte
+
+//go:embed cern_grid_ca.pem
+var cernGridCA []byte
+
+//go:embed cern_ca.pem
+var cernCA []byte
+
+// GetCERNCertsBundle returns the concatenated CERN CA certificates as a PEM bundle.
+func GetCERNCertsBundle() []byte {
+	bundle := make([]byte, 0, len(cernRootCA2)+len(cernGridCA)+len(cernCA))
+	bundle = append(bundle, cernRootCA2...)
+	bundle = append(bundle, cernGridCA...)
+	bundle = append(bundle, cernCA...)
+	return bundle
+}
+
+// GetCERNCertPool returns a new certificate pool containing CERN CA certificates.
+// This does NOT include system certificates - use AppendToCertPool to add to an existing pool.
+func GetCERNCertPool() (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	if err := appendCERNCerts(pool); err != nil {
+		return nil, err
+	}
+	return pool, nil
+}
+
+// GetSystemWithCERNCertPool returns a certificate pool containing both
+// the system's trusted certificates and CERN CA certificates.
+func GetSystemWithCERNCertPool() (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		// Fall back to empty pool if system certs can't be loaded
+		pool = x509.NewCertPool()
+	}
+	if err := appendCERNCerts(pool); err != nil {
+		return nil, err
+	}
+	return pool, nil
+}
+
+// appendCERNCerts adds all CERN CA certificates to the given pool.
+func appendCERNCerts(pool *x509.CertPool) error {
+	certs := []struct {
+		name string
+		data []byte
+	}{
+		{"CERN Root CA 2", cernRootCA2},
+		{"CERN Grid CA", cernGridCA},
+		{"CERN CA", cernCA},
+	}
+
+	for _, cert := range certs {
+		if !pool.AppendCertsFromPEM(cert.data) {
+			return fmt.Errorf("failed to parse %s certificate", cert.name)
+		}
+	}
+	return nil
+}

--- a/scripts/download_certs.sh
+++ b/scripts/download_certs.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Downloads CERN CA certificates for embedding in the binary.
+# These certificates are NOT stored in git, but downloaded during build.
+#
+# Certificates:
+# - CERN Root Certification Authority 2 (DER format, converted to PEM)
+# - CERN Grid Certification Authority
+# - CERN Certification Authority
+
+set -e
+
+# Get script directory (POSIX-compatible)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CERTS_DIR="${SCRIPT_DIR}/../pkg/auth/certs"
+
+mkdir -p "${CERTS_DIR}"
+
+echo "Downloading CERN CA certificates..."
+
+# CERN Root CA 2 (DER format, needs conversion)
+curl -fsSL 'https://cafiles.cern.ch/cafiles/certificates/CERN%20Root%20Certification%20Authority%202.crt' \
+  | openssl x509 -inform DER -out "${CERTS_DIR}/cern_root_ca2.pem"
+echo "  ✓ CERN Root Certification Authority 2"
+
+# CERN Grid CA (PEM format)
+curl -fsSL 'https://cafiles.cern.ch/cafiles/certificates/CERN%20Grid%20Certification%20Authority(1).crt' \
+  -o "${CERTS_DIR}/cern_grid_ca.pem"
+echo "  ✓ CERN Grid Certification Authority"
+
+# CERN CA (PEM format)
+curl -fsSL 'https://cafiles.cern.ch/cafiles/certificates/CERN%20Certification%20Authority.crt' \
+  -o "${CERTS_DIR}/cern_ca.pem"
+echo "  ✓ CERN Certification Authority"
+
+echo "Done! Certificates saved to ${CERTS_DIR}"
+


### PR DESCRIPTION
- Add multi-stage Dockerfile with Alpine base (24MB final image)
- Embed CERN CA certificates via go:embed (downloaded at build time)
- Add container.yml workflow for multi-arch builds (amd64/arm64) to ghcr.io
- Update kerberos.go to use CERN cert pool for TLS verification
- Add download-certs, docker-build, docker-push Makefile targets
- Update release.yml to download certs before building binaries
- Set KRB5CCNAME=/tmp/krb5cc in container for simpler usage


Fixes #26
Fixes #2 