### PR TITLE
feat(status): add HTTP verification option for cookie status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Go implementation of CERN SSO authentication tools. This is the Go equivalent 
 ## Features
 
 - Save SSO session cookies for use with curl, wget, etc.
-- Check cookie validity and expiration status
+- Check cookie expiration status (with optional HTTP verification)
 - Get OIDC access tokens via Authorization Code flow
 - Device Authorization Grant flow for headless environments
 - Cookie reuse: Existing auth.cern.ch cookies are reused for new CERN subdomains, avoiding redundant Kerberos authentication
@@ -199,13 +199,21 @@ For environments without Kerberos, use Device Authorization Grant:
 
 ### Check Cookie Status
 
-Display the validity and expiration information of stored cookies:
+Display the expiration information of stored cookies:
 
 ```bash
 ./cern-sso-cli status [--file cookies.txt] [--json]
 ```
 
-In quiet mode (`--quiet`), exits with code 0 if any valid cookies exist, 1 otherwise.
+**Important**: By default, `status` only checks cookie expiration times stored in the file **without making network requests**. This is fast but doesn't verify if cookies actually work.
+
+To verify cookies by making an actual HTTP request to a target URL:
+
+```bash
+./cern-sso-cli status --url https://gitlab.cern.ch [--file cookies.txt]
+```
+
+In quiet mode (`--quiet`), exits with code 0 if cookies are valid (and verified if `--url` is provided), 1 otherwise.
 
 Shows:
 
@@ -214,11 +222,14 @@ Shows:
 - Status: ✓ Valid, ✗ Expired, or Session
 - Remaining time for valid cookies
 - Security flags: [S] for Secure, [H] for HttpOnly
+- Verification status (when `--url` is used)
 
 Use `--json` flag for machine-readable output:
 
 ```bash
 ./cern-sso-cli status --json
+# With verification:
+./cern-sso-cli status --url https://gitlab.cern.ch --json
 ```
 
 ### Global Options
@@ -264,6 +275,9 @@ Use `--json` flag for machine-readable output:
 | ---- | ------- | ----------- |
 | `--file` | `cookies.txt` | Cookie file to check |
 | `--json` | `false` | Output as JSON instead of table format |
+| `--url` | (none) | URL to verify cookies against (makes HTTP request) |
+| `--insecure` or `-k` | `false` | Skip certificate validation when verifying |
+| `--auth-host` | `auth.cern.ch` | Authentication hostname for verification |
 
 ### Shell Completion
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,19 +10,32 @@ import (
 )
 
 var (
-	statusFile string
-	statusJSON bool
+	statusFile     string
+	statusJSON     bool
+	statusURL      string
+	statusInsecure bool
+	statusAuthHost string
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Check cookie validity and expiration status",
-	Long: `Display the validity and expiration information of stored cookies.
+	Short: "Check cookie expiration status",
+	Long: `Display the expiration information of stored cookies.
 
-In quiet mode (--quiet), exits with code 0 if any valid cookies exist, 1 otherwise.
+By default, this command only checks cookie expiration times stored in the file
+without making network requests.
 
-Example:
+To verify cookies actually work by making an HTTP request to a target URL,
+use the --url flag:
+
+  cern-sso-cli status --url https://gitlab.cern.ch --file cookies.txt
+
+In quiet mode (--quiet), exits with code 0 if cookies are valid (and verified
+if --url is provided), 1 otherwise.
+
+Examples:
   cern-sso-cli status --file cookies.txt
+  cern-sso-cli status --url https://gitlab.cern.ch --file cookies.txt
   cern-sso-cli status --json`,
 	RunE: runStatus,
 }
@@ -32,6 +45,9 @@ func init() {
 
 	statusCmd.Flags().StringVar(&statusFile, "file", "cookies.txt", "Cookie file to check")
 	statusCmd.Flags().BoolVar(&statusJSON, "json", false, "Output as JSON instead of table format")
+	statusCmd.Flags().StringVar(&statusURL, "url", "", "URL to verify cookies against (makes HTTP request)")
+	statusCmd.Flags().BoolVarP(&statusInsecure, "insecure", "k", false, "Skip certificate validation when verifying")
+	statusCmd.Flags().StringVar(&statusAuthHost, "auth-host", defaultAuthHostname, "Authentication hostname for verification")
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
@@ -40,22 +56,41 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load cookies from %s: %w", statusFile, err)
 	}
 
+	// Verify cookies if URL is provided
+	var verified bool
+	var verifiedValid bool
+	if statusURL != "" {
+		verified = true
+		verifiedValid, _ = cookie.VerifyCookies(statusURL, statusAuthHost, cookies, !statusInsecure)
+	}
+
 	if quiet {
 		// In quiet mode, exit with code based on cookie validity
-		now := time.Now()
-		hasValidCookies := false
-		for _, c := range cookies {
-			if c.Expires.IsZero() || c.Expires.After(now) {
-				hasValidCookies = true
-				break
+		if verified {
+			// If verification was requested, use actual verification result
+			if verifiedValid {
+				os.Exit(0)
+			} else {
+				os.Exit(1)
+			}
+		} else {
+			// Without verification, check expiry times only
+			now := time.Now()
+			hasValidCookies := false
+			for _, c := range cookies {
+				if c.Expires.IsZero() || c.Expires.After(now) {
+					hasValidCookies = true
+					break
+				}
+			}
+			if hasValidCookies {
+				os.Exit(0)
+			} else {
+				os.Exit(1)
 			}
 		}
-		if hasValidCookies {
-			os.Exit(0)
-		} else {
-			os.Exit(1)
-		}
 	}
-	cookie.PrintStatus(cookies, statusJSON, os.Stdout)
+
+	cookie.PrintStatus(cookies, statusJSON, verified, verifiedValid, os.Stdout)
 	return nil
 }


### PR DESCRIPTION
- Add `--url` flag to verify cookies by making HTTP requests to target URLs.
- Include `--insecure` and `--auth-host` flags for verification configuration.
- Update status output to show verification status in both table and JSON formats.

Fixes #19 