### PR TITLE
feat(auth): add OTP command integration for password managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,51 @@ Logging in with Kerberos...
 Enter your 6-digit OTP code for alice@CERN.CH: 123456
 ```
 
+##### Password Manager Integration
+
+You can automate OTP entry using password manager CLI tools:
+
+**1Password:**
+
+```bash
+# Using --otp-command flag
+./cern-sso-cli cookie --url https://gitlab.cern.ch --otp-command "op item get CERN --otp"
+
+# Using environment variable (set once)
+export CERN_SSO_OTP_COMMAND="op item get CERN --otp"
+./cern-sso-cli cookie --url https://gitlab.cern.ch
+```
+
+**Bitwarden:**
+
+```bash
+./cern-sso-cli cookie --url https://gitlab.cern.ch --otp-command "bw get totp CERN"
+```
+
+**Direct OTP Value:**
+
+```bash
+# Provide OTP directly (useful for scripts)
+./cern-sso-cli cookie --url https://gitlab.cern.ch --otp 123456
+
+# Or via environment variable
+export CERN_SSO_OTP=123456
+./cern-sso-cli cookie --url https://gitlab.cern.ch
+```
+
+**Priority Order:** The tool checks OTP sources in this order:
+
+1. `--otp` flag
+2. `--otp-command` flag
+3. `CERN_SSO_OTP` environment variable
+4. `CERN_SSO_OTP_COMMAND` environment variable
+5. Interactive prompt (default)
+
 **Important Notes:**
 
 - Only software token-based 2FA is supported
 - Hardware dongles (e.g., YubiKey) are **not currently supported**
-- The OTP code is entered interactively and is not stored anywhere
+- OTP codes are validated to be exactly 6 digits
 
 ### Save SSO Cookies
 
@@ -239,6 +279,8 @@ Use `--json` flag for machine-readable output:
 | `--quiet` or `-q` | `false` | Suppress all output (except critical errors). Exit code 0 on success, non-zero otherwise. |
 | `--user` or `-u` | (none) | Use specific CERN.CH Kerberos principal (e.g., `clange` or `clange@CERN.CH`). See [Multiple Kerberos Credentials](#multiple-kerberos-credentials). |
 | `--krb5-config` | `embedded` | Kerberos config source: `embedded` (built-in CERN.CH config), `system` (uses `/etc/krb5.conf` or `KRB5_CONFIG` env var), or a file path |
+| `--otp` | (none) | 6-digit OTP code for 2FA (alternative to interactive prompt) |
+| `--otp-command` | (none) | Command to execute to get OTP (e.g., `op item get CERN --otp`) |
 
 ### Cookie Command
 
@@ -330,6 +372,8 @@ cern-sso-cli completion fish > ~/.config/fish/completions/cern-sso-cli.fish
 | `KRB_PASSWORD` | Kerberos password |
 | `KRB5CCNAME` | Path to Kerberos credential cache |
 | `KRB5_CONFIG` | Path to system krb5.conf (used with `--krb5-config system`) |
+| `CERN_SSO_OTP` | 6-digit OTP code for 2FA |
+| `CERN_SSO_OTP_COMMAND` | Command to execute to get OTP code |
 
 ## Comparison to Python Version
 

--- a/cmd/cookie.go
+++ b/cmd/cookie.go
@@ -132,6 +132,9 @@ func tryAuthCookies(targetURL, authHost string, cookies []*http.Cookie, insecure
 		return false, nil, nil
 	}
 
+	// Configure OTP provider for 2FA support
+	kerbClient.SetOTPProvider(GetOTPProvider())
+
 	result, err := kerbClient.TryLoginWithCookies(targetURL, authHost, cookies)
 	if err != nil {
 		kerbClient.Close()
@@ -182,6 +185,9 @@ func authenticateWithKerberos(targetURL, filename, authHost string, insecure boo
 		return fmt.Errorf("failed to initialize Kerberos: %w", err)
 	}
 	defer kerbClient.Close()
+
+	// Configure OTP provider for 2FA support
+	kerbClient.SetOTPProvider(GetOTPProvider())
 
 	logPrintln("Logging in with Kerberos...")
 	result, err := kerbClient.LoginWithKerberos(targetURL, authHost, !insecure)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ var (
 	quiet      bool
 	krbUser    string
 	krb5Config string
+	otpCode    string
+	otpCommand string
 )
 
 // version is set from main.go
@@ -60,6 +62,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress all output (except critical errors)")
 	rootCmd.PersistentFlags().StringVarP(&krbUser, "user", "u", "", "Use specific CERN.CH Kerberos principal (e.g., clange or clange@CERN.CH)")
 	rootCmd.PersistentFlags().StringVar(&krb5Config, "krb5-config", "", "Kerberos config source: 'embedded' (default), 'system', or file path")
+	rootCmd.PersistentFlags().StringVar(&otpCode, "otp", "", "6-digit OTP code for 2FA (alternative to prompt)")
+	rootCmd.PersistentFlags().StringVar(&otpCommand, "otp-command", "", "Command to execute to get OTP (e.g., 'op item get CERN --otp')")
 }
 
 // logInfo prints a formatted message if not in quiet mode.
@@ -98,4 +102,12 @@ func formatDuration(d time.Duration) string {
 // This is a convenience wrapper around auth.NormalizePrincipal.
 func normalizeUsername(username string) string {
 	return auth.NormalizePrincipal(username)
+}
+
+// GetOTPProvider returns an OTP provider configured with CLI flags.
+func GetOTPProvider() *auth.OTPProvider {
+	return &auth.OTPProvider{
+		OTP:        otpCode,
+		OTPCommand: otpCommand,
+	}
 }

--- a/pkg/auth/otp.go
+++ b/pkg/auth/otp.go
@@ -1,0 +1,129 @@
+// Package auth provides authentication utilities for CERN SSO.
+package auth
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// OTP source priority constants
+const (
+	OTPSourceFlag    = "flag"
+	OTPSourceCommand = "command"
+	OTPSourceEnv     = "env"
+	OTPSourcePrompt  = "prompt"
+)
+
+// Environment variable names for OTP configuration
+const (
+	EnvOTP        = "CERN_SSO_OTP"
+	EnvOTPCommand = "CERN_SSO_OTP_COMMAND"
+)
+
+// OTPProvider handles OTP code retrieval from various sources.
+// It checks sources in priority order: flag > command > env > prompt.
+type OTPProvider struct {
+	OTP        string // Direct OTP value (from --otp flag or CERN_SSO_OTP)
+	OTPCommand string // Command to execute (from --otp-command flag or CERN_SSO_OTP_COMMAND)
+}
+
+// GetOTP retrieves an OTP code using the configured sources.
+// It tries sources in priority order:
+//  1. Direct OTP value (p.OTP)
+//  2. OTP command (p.OTPCommand)
+//  3. CERN_SSO_OTP environment variable
+//  4. CERN_SSO_OTP_COMMAND environment variable
+//  5. Interactive prompt (fallback)
+//
+// Returns the OTP code and the source it was retrieved from.
+func (p *OTPProvider) GetOTP(username string) (string, string, error) {
+	// Priority 1: Direct OTP from flag
+	if p.OTP != "" {
+		otp, err := validateOTP(p.OTP)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid OTP from flag: %w", err)
+		}
+		return otp, OTPSourceFlag, nil
+	}
+
+	// Priority 2: OTP command from flag
+	if p.OTPCommand != "" {
+		otp, err := executeOTPCommand(p.OTPCommand)
+		if err != nil {
+			return "", "", fmt.Errorf("OTP command failed: %w", err)
+		}
+		return otp, OTPSourceCommand, nil
+	}
+
+	// Priority 3: CERN_SSO_OTP environment variable
+	if envOTP := os.Getenv(EnvOTP); envOTP != "" {
+		otp, err := validateOTP(envOTP)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid OTP from %s: %w", EnvOTP, err)
+		}
+		return otp, OTPSourceEnv, nil
+	}
+
+	// Priority 4: CERN_SSO_OTP_COMMAND environment variable
+	if envCmd := os.Getenv(EnvOTPCommand); envCmd != "" {
+		otp, err := executeOTPCommand(envCmd)
+		if err != nil {
+			return "", "", fmt.Errorf("OTP command from %s failed: %w", EnvOTPCommand, err)
+		}
+		return otp, OTPSourceEnv, nil
+	}
+
+	// Priority 5: Interactive prompt
+	otp, err := promptForOTPInteractive(username)
+	if err != nil {
+		return "", "", err
+	}
+	return otp, OTPSourcePrompt, nil
+}
+
+// executeOTPCommand runs a shell command and returns its output as an OTP.
+func executeOTPCommand(command string) (string, error) {
+	// Use shell to execute the command (supports pipes, etc.)
+	cmd := exec.Command("sh", "-c", command)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("command exited with status %d: %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return "", err
+	}
+
+	otp := strings.TrimSpace(string(output))
+	return validateOTP(otp)
+}
+
+// validateOTP validates that the OTP is a 6-digit code.
+func validateOTP(otp string) (string, error) {
+	otp = strings.TrimSpace(otp)
+	if len(otp) != 6 {
+		return "", fmt.Errorf("OTP must be 6 digits, got %d characters", len(otp))
+	}
+	for _, c := range otp {
+		if c < '0' || c > '9' {
+			return "", fmt.Errorf("OTP must contain only digits")
+		}
+	}
+	return otp, nil
+}
+
+// promptForOTPInteractive prompts the user interactively for an OTP code.
+func promptForOTPInteractive(username string) (string, error) {
+	if username != "" {
+		fmt.Printf("Enter your 6-digit OTP code for %s: ", username)
+	} else {
+		fmt.Print("Enter your 6-digit OTP code: ")
+	}
+	var code string
+	_, err := fmt.Scanln(&code)
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	return validateOTP(code)
+}

--- a/pkg/auth/otp_test.go
+++ b/pkg/auth/otp_test.go
@@ -1,0 +1,231 @@
+package auth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestValidateOTP_Valid(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"123456", "123456"},
+		{" 123456 ", "123456"}, // with whitespace
+		{"000000", "000000"},
+		{"999999", "999999"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := validateOTP(tc.input)
+			if err != nil {
+				t.Errorf("validateOTP(%q) returned error: %v", tc.input, err)
+			}
+			if result != tc.expected {
+				t.Errorf("validateOTP(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestValidateOTP_Invalid(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr string
+	}{
+		{"12345", "OTP must be 6 digits"},
+		{"1234567", "OTP must be 6 digits"},
+		{"", "OTP must be 6 digits"},
+		{"abcdef", "OTP must contain only digits"},
+		{"12345a", "OTP must contain only digits"},
+		{"12 345", "OTP must contain only digits"}, // space in middle
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			_, err := validateOTP(tc.input)
+			if err == nil {
+				t.Errorf("validateOTP(%q) expected error, got nil", tc.input)
+				return
+			}
+			if !contains(err.Error(), tc.wantErr) {
+				t.Errorf("validateOTP(%q) error = %q, want to contain %q", tc.input, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestExecuteOTPCommand_Success(t *testing.T) {
+	// Test with echo command
+	otp, err := executeOTPCommand("echo 123456")
+	if err != nil {
+		t.Fatalf("executeOTPCommand failed: %v", err)
+	}
+	if otp != "123456" {
+		t.Errorf("executeOTPCommand returned %q, want %q", otp, "123456")
+	}
+}
+
+func TestExecuteOTPCommand_WithWhitespace(t *testing.T) {
+	// Command output with newline should be trimmed
+	otp, err := executeOTPCommand("echo '  654321  '")
+	if err != nil {
+		t.Fatalf("executeOTPCommand failed: %v", err)
+	}
+	if otp != "654321" {
+		t.Errorf("executeOTPCommand returned %q, want %q", otp, "654321")
+	}
+}
+
+func TestExecuteOTPCommand_InvalidOutput(t *testing.T) {
+	// Command returns invalid OTP
+	_, err := executeOTPCommand("echo 'not-an-otp'")
+	if err == nil {
+		t.Error("executeOTPCommand expected error for invalid OTP, got nil")
+	}
+}
+
+func TestExecuteOTPCommand_CommandFailure(t *testing.T) {
+	// Command that fails
+	_, err := executeOTPCommand("exit 1")
+	if err == nil {
+		t.Error("executeOTPCommand expected error for failed command, got nil")
+	}
+}
+
+func TestExecuteOTPCommand_NonexistentCommand(t *testing.T) {
+	// Non-existent command
+	_, err := executeOTPCommand("nonexistent-command-12345")
+	if err == nil {
+		t.Error("executeOTPCommand expected error for nonexistent command, got nil")
+	}
+}
+
+func TestOTPProvider_DirectOTP(t *testing.T) {
+	p := &OTPProvider{OTP: "123456"}
+	otp, source, err := p.GetOTP("testuser")
+	if err != nil {
+		t.Fatalf("GetOTP failed: %v", err)
+	}
+	if otp != "123456" {
+		t.Errorf("GetOTP returned %q, want %q", otp, "123456")
+	}
+	if source != OTPSourceFlag {
+		t.Errorf("GetOTP source = %q, want %q", source, OTPSourceFlag)
+	}
+}
+
+func TestOTPProvider_Command(t *testing.T) {
+	p := &OTPProvider{OTPCommand: "echo 654321"}
+	otp, source, err := p.GetOTP("testuser")
+	if err != nil {
+		t.Fatalf("GetOTP failed: %v", err)
+	}
+	if otp != "654321" {
+		t.Errorf("GetOTP returned %q, want %q", otp, "654321")
+	}
+	if source != OTPSourceCommand {
+		t.Errorf("GetOTP source = %q, want %q", source, OTPSourceCommand)
+	}
+}
+
+func TestOTPProvider_FlagTakesPrecedence(t *testing.T) {
+	// Both flag and command set - flag should win
+	p := &OTPProvider{
+		OTP:        "111111",
+		OTPCommand: "echo 222222",
+	}
+	otp, source, err := p.GetOTP("testuser")
+	if err != nil {
+		t.Fatalf("GetOTP failed: %v", err)
+	}
+	if otp != "111111" {
+		t.Errorf("GetOTP returned %q, want %q (flag should take precedence)", otp, "111111")
+	}
+	if source != OTPSourceFlag {
+		t.Errorf("GetOTP source = %q, want %q", source, OTPSourceFlag)
+	}
+}
+
+func TestOTPProvider_EnvVar(t *testing.T) {
+	// Set environment variable
+	os.Setenv(EnvOTP, "333333")
+	defer os.Unsetenv(EnvOTP)
+
+	p := &OTPProvider{} // No flags set
+	otp, source, err := p.GetOTP("testuser")
+	if err != nil {
+		t.Fatalf("GetOTP failed: %v", err)
+	}
+	if otp != "333333" {
+		t.Errorf("GetOTP returned %q, want %q", otp, "333333")
+	}
+	if source != OTPSourceEnv {
+		t.Errorf("GetOTP source = %q, want %q", source, OTPSourceEnv)
+	}
+}
+
+func TestOTPProvider_EnvCommand(t *testing.T) {
+	// Set environment variable for command
+	os.Setenv(EnvOTPCommand, "echo 444444")
+	defer os.Unsetenv(EnvOTPCommand)
+
+	p := &OTPProvider{} // No flags set
+	otp, source, err := p.GetOTP("testuser")
+	if err != nil {
+		t.Fatalf("GetOTP failed: %v", err)
+	}
+	if otp != "444444" {
+		t.Errorf("GetOTP returned %q, want %q", otp, "444444")
+	}
+	if source != OTPSourceEnv {
+		t.Errorf("GetOTP source = %q, want %q", source, OTPSourceEnv)
+	}
+}
+
+func TestOTPProvider_FlagOverridesEnv(t *testing.T) {
+	// Set environment variable
+	os.Setenv(EnvOTP, "555555")
+	defer os.Unsetenv(EnvOTP)
+
+	// Flag should override env
+	p := &OTPProvider{OTP: "666666"}
+	otp, _, err := p.GetOTP("testuser")
+	if err != nil {
+		t.Fatalf("GetOTP failed: %v", err)
+	}
+	if otp != "666666" {
+		t.Errorf("GetOTP returned %q, want %q (flag should override env)", otp, "666666")
+	}
+}
+
+func TestOTPProvider_InvalidDirectOTP(t *testing.T) {
+	p := &OTPProvider{OTP: "bad"}
+	_, _, err := p.GetOTP("testuser")
+	if err == nil {
+		t.Error("GetOTP expected error for invalid OTP, got nil")
+	}
+}
+
+func TestOTPProvider_InvalidCommandOutput(t *testing.T) {
+	p := &OTPProvider{OTPCommand: "echo invalid"}
+	_, _, err := p.GetOTP("testuser")
+	if err == nil {
+		t.Error("GetOTP expected error for invalid command output, got nil")
+	}
+}
+
+// Helper function for string contains check
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Add support for OTP codes from password managers (1Password, Bitwarden, etc.) via CLI flags and environment variables.

New features:
- --otp flag for direct 6-digit OTP value
- --otp-command flag for executing commands to get OTP
- CERN_SSO_OTP environment variable for direct OTP value
- CERN_SSO_OTP_COMMAND environment variable for OTP command

Priority order: flag > command > env var > interactive prompt

Files added:
- pkg/auth/otp.go: OTP provider abstraction
- pkg/auth/otp_test.go: Comprehensive unit tests

Files modified:
- cmd/root.go: Add global --otp and --otp-command flags
- cmd/cookie.go: Integrate OTP provider with Kerberos client
- pkg/auth/kerberos.go: Add SetOTPProvider and getOTP methods
- README.md: Document new OTP options with examples

Fixes #24 