### PR TITLE
feat(auth): add OTP retry mechanism for expired codes and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,24 @@ export CERN_SSO_OTP=123456
 4. `CERN_SSO_OTP_COMMAND` environment variable
 5. Interactive prompt (default)
 
+##### OTP Retry
+
+If an OTP fails (expired or typo), the tool automatically retries:
+
+- **Command sources** (`--otp-command`): Waits 3 seconds for TOTP window rollover, then re-executes the command
+- **Interactive prompt**: Re-prompts with "Invalid OTP. Try again (2/3):"
+- **Static values** (`--otp` flag): Cannot retry (fails immediately)
+
+Use `--otp-retries` to configure retry behavior:
+
+```bash
+# Custom retry count
+./cern-sso-cli cookie --url https://gitlab.cern.ch --otp-retries 5
+
+# Disable retry (fail on first error)
+./cern-sso-cli cookie --url https://gitlab.cern.ch --otp-retries 1
+```
+
 **Important Notes:**
 
 - Only software token-based 2FA is supported
@@ -281,6 +299,7 @@ Use `--json` flag for machine-readable output:
 | `--krb5-config` | `embedded` | Kerberos config source: `embedded` (built-in CERN.CH config), `system` (uses `/etc/krb5.conf` or `KRB5_CONFIG` env var), or a file path |
 | `--otp` | (none) | 6-digit OTP code for 2FA (alternative to interactive prompt) |
 | `--otp-command` | (none) | Command to execute to get OTP (e.g., `op item get CERN --otp`) |
+| `--otp-retries` | `3` | Max OTP retry attempts (0 to disable retry) |
 
 ### Cookie Command
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var (
 	krb5Config string
 	otpCode    string
 	otpCommand string
+	otpRetries int
 )
 
 // version is set from main.go
@@ -64,6 +65,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&krb5Config, "krb5-config", "", "Kerberos config source: 'embedded' (default), 'system', or file path")
 	rootCmd.PersistentFlags().StringVar(&otpCode, "otp", "", "6-digit OTP code for 2FA (alternative to prompt)")
 	rootCmd.PersistentFlags().StringVar(&otpCommand, "otp-command", "", "Command to execute to get OTP (e.g., 'op item get CERN --otp')")
+	rootCmd.PersistentFlags().IntVar(&otpRetries, "otp-retries", 3, "Max OTP retry attempts (0 to disable retry)")
 }
 
 // logInfo prints a formatted message if not in quiet mode.
@@ -109,5 +111,6 @@ func GetOTPProvider() *auth.OTPProvider {
 	return &auth.OTPProvider{
 		OTP:        otpCode,
 		OTPCommand: otpCommand,
+		MaxRetries: otpRetries,
 	}
 }


### PR DESCRIPTION
Add automatic retry support for OTP failures:
- Command sources: wait 3s for TOTP window rollover, re-execute command
- Interactive prompt: re-prompt user with attempt counter
- Static flag values: fail immediately (cannot refresh)

New features:
- --otp-retries flag (default: 3) to configure max retry attempts
- RefreshOTP method for getting fresh OTP codes
- IsRefreshable helper to check if source supports retry

Implementation:
- Add retry loop in LoginWithKerberos OTP handling
- Add GetMaxRetries, RefreshOTP methods to OTPProvider
- Add getMaxOTPRetries, refreshOTP methods to KerberosClient
- Add 8 new unit tests for retry functionality

Files modified:
- pkg/auth/otp.go: Add MaxRetries field, RefreshOTP, IsRefreshable
- pkg/auth/otp_test.go: Add retry tests (GetMaxRetries, RefreshOTP)
- pkg/auth/kerberos.go: Add retry loop and helper methods
- cmd/root.go: Add --otp-retries flag
- README.md: Document OTP retry behavior

Fixes #23 