### PR TITLE
feat(auth): add keytab support and improve kerberos auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
   integration-ccache:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      KRB5_USERNAME: ${{ secrets.KRB5_USERNAME }}
+      KRB5_PASSWORD: ${{ secrets.KRB5_PASSWORD }}
     steps:
     - uses: actions/checkout@v6
 
@@ -86,25 +89,19 @@ jobs:
         EOF
 
     - name: Get Kerberos ticket via kinit
-      if: env.KRB_USERNAME != '' && env.KRB_PASSWORD != ''
-      env:
-        KRB_USERNAME: ${{ secrets.KRB_USERNAME }}
-        KRB_PASSWORD: ${{ secrets.KRB_PASSWORD }}
+      if: env.KRB5_USERNAME != '' && env.KRB5_PASSWORD != ''
       run: |
-        echo "$KRB_PASSWORD" | kinit "${KRB_USERNAME}@CERN.CH"
+        echo "$KRB5_PASSWORD" | kinit "${KRB5_USERNAME}@CERN.CH"
         klist
 
     - name: Build
       run: make build
 
     - name: Test with credential cache (no password env vars)
-      if: env.KRB_USERNAME != '' && env.KRB_PASSWORD != ''
-      env:
-        KRB_USERNAME: ${{ secrets.KRB_USERNAME }}
-        KRB_PASSWORD: ${{ secrets.KRB_PASSWORD }}
+      if: env.KRB5_USERNAME != '' && env.KRB5_PASSWORD != ''
       run: |
         # Unset password env vars to ensure we use ccache
-        unset KRB_USERNAME KRB_PASSWORD
+        unset KRB5_USERNAME KRB5_PASSWORD
         
         # Test cookie command with ccache
         ./cern-sso-cli cookie --url https://gitlab.cern.ch --file test_cookies.txt
@@ -122,6 +119,9 @@ jobs:
   integration-password:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      KRB5_USERNAME: ${{ secrets.KRB5_USERNAME }}
+      KRB5_PASSWORD: ${{ secrets.KRB5_PASSWORD }}
     steps:
     - uses: actions/checkout@v6
 
@@ -143,11 +143,78 @@ jobs:
       run: make download-certs
 
     - name: Run Integration Tests
-      if: env.KRB_USERNAME != '' && env.KRB_PASSWORD != ''
-      env:
-        KRB_USERNAME: ${{ secrets.KRB_USERNAME }}
-        KRB_PASSWORD: ${{ secrets.KRB_PASSWORD }}
+      if: env.KRB5_USERNAME != '' && env.KRB5_PASSWORD != ''
       run: make test-integration
+
+  # Integration tests using keytab (from cern-get-keytab)
+  integration-keytab:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      KRB5_KEYTAB: ${{ secrets.KRB5_KEYTAB }}
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25'
+        cache: true
+
+    - name: Install Kerberos and libfido2
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y krb5-user libfido2-dev
+
+    - name: Configure Kerberos
+      run: |
+        sudo tee /etc/krb5.conf << 'EOF'
+        [libdefaults]
+            default_realm = CERN.CH
+            dns_lookup_kdc = true
+        [realms]
+            CERN.CH = { kdc = cerndc.cern.ch }
+        [domain_realm]
+            .cern.ch = CERN.CH
+        EOF
+
+    - name: Download CERN CA certificates
+      run: make download-certs
+
+    - name: Build
+      run: make build
+
+    - name: Decode keytab from secret
+      if: env.KRB5_KEYTAB != ''
+      run: |
+        echo "${KRB5_KEYTAB}" | base64 -d > /tmp/test.keytab
+        chmod 600 /tmp/test.keytab
+        echo "=== Keytab contents ==="
+        klist -kt /tmp/test.keytab
+
+    - name: Test --keytab flag
+      if: env.KRB5_KEYTAB != ''
+      run: |
+        ./cern-sso-cli cookie --url https://gitlab.cern.ch --keytab /tmp/test.keytab --file test_cookies.txt
+        if [ ! -f test_cookies.txt ]; then
+          echo "ERROR: Cookie file not created with --keytab"
+          exit 1
+        fi
+        echo "SUCCESS: --keytab authentication works!"
+        cat test_cookies.txt
+
+    - name: Test --use-keytab with KRB5_KTNAME
+      if: env.KRB5_KEYTAB != ''
+      env:
+        KRB5_KTNAME: /tmp/test.keytab
+      run: |
+        rm -f test_cookies.txt
+        ./cern-sso-cli cookie --url https://gitlab.cern.ch --use-keytab --file test_cookies.txt
+        if [ ! -f test_cookies.txt ]; then
+          echo "ERROR: Cookie file not created with --use-keytab"
+          exit 1
+        fi
+        echo "SUCCESS: --use-keytab with KRB5_KTNAME works!"
 
   # Unit tests on macOS
   test-macos:
@@ -171,6 +238,9 @@ jobs:
   integration-macos:
     runs-on: macos-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      KRB5_USERNAME: ${{ secrets.KRB5_USERNAME }}
+      KRB5_PASSWORD: ${{ secrets.KRB5_PASSWORD }}
     steps:
     - uses: actions/checkout@v6
 
@@ -214,13 +284,10 @@ jobs:
         EOF
 
     - name: Get Kerberos ticket (file-based cache for CI)
-      if: env.KRB_USERNAME != '' && env.KRB_PASSWORD != ''
-      env:
-        KRB_USERNAME: ${{ secrets.KRB_USERNAME }}
-        KRB_PASSWORD: ${{ secrets.KRB_PASSWORD }}
+      if: env.KRB5_USERNAME != '' && env.KRB5_PASSWORD != ''
       run: |
         # Create file-based cache (keychain not available in CI)
-        echo "$KRB_PASSWORD" | kinit -c /tmp/krb5cc_ci "${KRB_USERNAME}@CERN.CH"
+        echo "$KRB5_PASSWORD" | kinit -c /tmp/krb5cc_ci "${KRB5_USERNAME}@CERN.CH"
         export KRB5CCNAME=/tmp/krb5cc_ci
         echo "=== Kerberos ticket (file-based cache) ==="
         klist
@@ -229,14 +296,12 @@ jobs:
       run: make build
 
     - name: Test with file-based cache
-      if: env.KRB_USERNAME != '' && env.KRB_PASSWORD != ''
+      if: env.KRB5_USERNAME != '' && env.KRB5_PASSWORD != ''
       env:
-        KRB_USERNAME: ${{ secrets.KRB_USERNAME }}
-        KRB_PASSWORD: ${{ secrets.KRB_PASSWORD }}
         KRB5CCNAME: /tmp/krb5cc_ci
       run: |
         # Unset password env vars to ensure we use ccache
-        unset KRB_USERNAME KRB_PASSWORD
+        unset KRB5_USERNAME KRB5_PASSWORD
 
         # Run with file-based cache
         ./cern-sso-cli cookie --url https://gitlab.cern.ch --file test_cookies.txt

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -51,15 +51,7 @@ make build-all-webauthn
 
 Binaries will be placed in the `dist/` directory with names like `cern-sso-cli-linux-amd64`.
 
-Build WebAuthn-enabled binaries (platform-specific builds):
 
-```bash
-# Must be built on target platform
-make build-darwin-amd64-webauthn     # macOS Intel (requires macOS + libfido2)
-make build-darwin-arm64-webauthn     # macOS Apple Silicon (requires macOS + libfido2)
-make build-linux-amd64-webauthn      # Linux AMD64 (requires libfido2-dev)
-make build-linux-arm64-webauthn      # Linux ARM64 (requires libfido2-dev)
-```
 
 **Note**: WebAuthn builds for Linux ARM64 and macOS Intel are available for manual builds but not included in releases due to CI limitations.
 
@@ -84,8 +76,8 @@ Multi-architecture container images (amd64/arm64) are available from GitHub Cont
 Run integration tests (requires CERN credentials and network access):
 
 ```bash
-export KRB_USERNAME='your-username'
-export KRB_PASSWORD='your-password'
+export KRB5_USERNAME='your-username'
+export KRB5_PASSWORD='your-password'
 make test-integration
 ```
 

--- a/cmd/cookie.go
+++ b/cmd/cookie.go
@@ -58,6 +58,9 @@ func runCookie(cmd *cobra.Command, args []string) error {
 	if err := ValidateMethodFlags(); err != nil {
 		return err
 	}
+	if err := ValidateAuthMethodFlags(); err != nil {
+		return err
+	}
 
 	// Extract domain from target URL for cookie matching
 	u, err := url.Parse(cookieURL)
@@ -142,7 +145,8 @@ func runCookie(cmd *cobra.Command, args []string) error {
 
 // tryAuthCookies attempts to authenticate using existing auth cookies.
 func tryAuthCookies(targetURL, authHost string, cookies []*http.Cookie, insecure bool) (bool, *auth.LoginResult, *auth.KerberosClient) {
-	kerbClient, err := auth.NewKerberosClientWithUser(version, krb5Config, krbUser, !insecure)
+	authConfig := GetAuthConfig()
+	kerbClient, err := auth.NewKerberosClientWithConfig(version, krb5Config, krbUser, !insecure, authConfig)
 	if err != nil {
 		logInfo("Warning: Failed to create Kerberos client for cookie attempt: %v\n", err)
 		return false, nil, nil
@@ -216,7 +220,8 @@ func printCookieOutput(output *CookieOutput) {
 // authenticateWithKerberos performs full Kerberos authentication flow.
 func authenticateWithKerberos(targetURL, filename, authHost string, insecure bool) error {
 	logPrintln("Initializing Kerberos client...")
-	kerbClient, err := auth.NewKerberosClientWithUser(version, krb5Config, krbUser, !insecure)
+	authConfig := GetAuthConfig()
+	kerbClient, err := auth.NewKerberosClientWithConfig(version, krb5Config, krbUser, !insecure, authConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Kerberos: %w", err)
 	}

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -54,9 +54,13 @@ func runToken(cmd *cobra.Command, args []string) error {
 	if err := ValidateMethodFlags(); err != nil {
 		return err
 	}
+	if err := ValidateAuthMethodFlags(); err != nil {
+		return err
+	}
 
 	logPrintln("Initializing Kerberos client...")
-	kerbClient, err := auth.NewKerberosClientWithUser(version, krb5Config, krbUser, !tokenInsecure)
+	authConfig := GetAuthConfig()
+	kerbClient, err := auth.NewKerberosClientWithConfig(version, krb5Config, krbUser, !tokenInsecure, authConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Kerberos: %w", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,7 +3,7 @@
 
 // Package main provides integration tests for the CERN SSO authentication tool.
 // These tests require:
-// - KRB_USERNAME and KRB_PASSWORD environment variables set
+// - KRB5_USERNAME and KRB5_PASSWORD environment variables set
 // - Network access to CERN Kerberos and SSO endpoints
 //
 // Run with: go test -tags=integration -v ./...
@@ -324,24 +324,24 @@ func TestIntegration_AuthorizationCodeFlow(t *testing.T) {
 
 func TestIntegration_InvalidCredentials(t *testing.T) {
 	// Set wrong password and dummy username to force password-based auth
-	originalUser := os.Getenv("KRB_USERNAME")
-	originalPassword := os.Getenv("KRB_PASSWORD")
+	originalUser := os.Getenv("KRB5_USERNAME")
+	originalPassword := os.Getenv("KRB5_PASSWORD")
 	originalCCache := os.Getenv("KRB5CCNAME")
 
-	os.Setenv("KRB_USERNAME", "testuser")
-	os.Setenv("KRB_PASSWORD", "wrong-password")
+	os.Setenv("KRB5_USERNAME", "testuser")
+	os.Setenv("KRB5_PASSWORD", "wrong-password")
 	os.Setenv("KRB5CCNAME", "/tmp/non-existent-ccache-path")
 
 	defer func() {
 		if originalUser != "" {
-			os.Setenv("KRB_USERNAME", originalUser)
+			os.Setenv("KRB5_USERNAME", originalUser)
 		} else {
-			os.Unsetenv("KRB_USERNAME")
+			os.Unsetenv("KRB5_USERNAME")
 		}
 		if originalPassword != "" {
-			os.Setenv("KRB_PASSWORD", originalPassword)
+			os.Setenv("KRB5_PASSWORD", originalPassword)
 		} else {
-			os.Unsetenv("KRB_PASSWORD")
+			os.Unsetenv("KRB5_PASSWORD")
 		}
 		if originalCCache != "" {
 			os.Setenv("KRB5CCNAME", originalCCache)
@@ -361,8 +361,8 @@ func TestIntegration_InvalidCredentials(t *testing.T) {
 }
 
 func skipIfNoCredentials(t *testing.T) {
-	if os.Getenv("KRB_USERNAME") == "" || os.Getenv("KRB_PASSWORD") == "" {
-		t.Skip("Skipping integration test: KRB_USERNAME and KRB_PASSWORD not set")
+	if os.Getenv("KRB5_USERNAME") == "" || os.Getenv("KRB5_PASSWORD") == "" {
+		t.Skip("Skipping integration test: KRB5_USERNAME and KRB5_PASSWORD not set")
 	}
 }
 

--- a/pkg/auth/ccache.go
+++ b/pkg/auth/ccache.go
@@ -27,9 +27,10 @@ func NormalizePrincipal(username string) string {
 	if !strings.Contains(username, "@") {
 		username = username + "@CERN.CH"
 	}
-	if strings.HasSuffix(strings.ToLower(username), "@cern.ch") {
-		parts := strings.Split(username, "@")
-		username = parts[0] + "@CERN.CH"
+	suffix := "@cern.ch"
+	lower := strings.ToLower(username)
+	if strings.HasSuffix(lower, suffix) {
+		username = username[:len(username)-len(suffix)] + "@CERN.CH"
 	}
 	return username
 }

--- a/pkg/auth/insecure_test.go
+++ b/pkg/auth/insecure_test.go
@@ -30,10 +30,10 @@ func TestNewKerberosClientWithInsecureCert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("KRB_USERNAME", "test")
-			os.Setenv("KRB_PASSWORD", "test")
-			defer os.Unsetenv("KRB_USERNAME")
-			defer os.Unsetenv("KRB_PASSWORD")
+			os.Setenv("KRB5_USERNAME", "test")
+			os.Setenv("KRB5_PASSWORD", "test")
+			defer os.Unsetenv("KRB5_USERNAME")
+			defer os.Unsetenv("KRB5_PASSWORD")
 
 			cfg, _ := loadTestKrb5Config()
 			cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
@@ -72,10 +72,10 @@ func TestNewKerberosClientWithInsecureCert(t *testing.T) {
 // TestLoginWithKerberosWithInsecureCert verifies that LoginWithKerberos respects
 // the verifyCert parameter when making HTTP requests
 func TestLoginWithKerberosWithInsecureCert(t *testing.T) {
-	os.Setenv("KRB_USERNAME", "test")
-	os.Setenv("KRB_PASSWORD", "test")
-	defer os.Unsetenv("KRB_USERNAME")
-	defer os.Unsetenv("KRB_PASSWORD")
+	os.Setenv("KRB5_USERNAME", "test")
+	os.Setenv("KRB5_PASSWORD", "test")
+	defer os.Unsetenv("KRB5_USERNAME")
+	defer os.Unsetenv("KRB5_PASSWORD")
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))

--- a/pkg/auth/kerberos_test.go
+++ b/pkg/auth/kerberos_test.go
@@ -97,10 +97,10 @@ func TestLoadKrb5Config_System(t *testing.T) {
 
 func TestTryLoginWithCookies_NoCookies(t *testing.T) {
 	// Set up credentials for the test
-	os.Setenv("KRB_USERNAME", "test")
-	os.Setenv("KRB_PASSWORD", "test")
-	defer os.Unsetenv("KRB_USERNAME")
-	defer os.Unsetenv("KRB_PASSWORD")
+	os.Setenv("KRB5_USERNAME", "test")
+	os.Setenv("KRB5_PASSWORD", "test")
+	defer os.Unsetenv("KRB5_USERNAME")
+	defer os.Unsetenv("KRB5_PASSWORD")
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
@@ -118,10 +118,10 @@ func TestTryLoginWithCookies_NoCookies(t *testing.T) {
 
 func TestTryLoginWithCookies_InvalidRedirect(t *testing.T) {
 	// Set up credentials for the test
-	os.Setenv("KRB_USERNAME", "test")
-	os.Setenv("KRB_PASSWORD", "test")
-	defer os.Unsetenv("KRB_USERNAME")
-	defer os.Unsetenv("KRB_PASSWORD")
+	os.Setenv("KRB5_USERNAME", "test")
+	os.Setenv("KRB5_PASSWORD", "test")
+	defer os.Unsetenv("KRB5_USERNAME")
+	defer os.Unsetenv("KRB5_PASSWORD")
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
@@ -146,10 +146,10 @@ func TestTryLoginWithCookies_InvalidRedirect(t *testing.T) {
 
 func TestTryLoginWithCookies_Success(t *testing.T) {
 	// Set up credentials for the test
-	os.Setenv("KRB_USERNAME", "test")
-	os.Setenv("KRB_PASSWORD", "test")
-	defer os.Unsetenv("KRB_USERNAME")
-	defer os.Unsetenv("KRB_PASSWORD")
+	os.Setenv("KRB5_USERNAME", "test")
+	os.Setenv("KRB5_PASSWORD", "test")
+	defer os.Unsetenv("KRB5_USERNAME")
+	defer os.Unsetenv("KRB5_PASSWORD")
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
@@ -182,10 +182,10 @@ func loadTestKrb5Config() (*config.Config, error) {
 
 func TestTryLoginWithCookies_VerifiesCookiesSent(t *testing.T) {
 	// Set up credentials for the test
-	os.Setenv("KRB_USERNAME", "test")
-	os.Setenv("KRB_PASSWORD", "test")
-	defer os.Unsetenv("KRB_USERNAME")
-	defer os.Unsetenv("KRB_PASSWORD")
+	os.Setenv("KRB5_USERNAME", "test")
+	os.Setenv("KRB5_PASSWORD", "test")
+	defer os.Unsetenv("KRB5_USERNAME")
+	defer os.Unsetenv("KRB5_PASSWORD")
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))
@@ -242,10 +242,10 @@ func TestTryLoginWithCookies_VerifiesCookiesSent(t *testing.T) {
 
 func TestTryLoginWithCookies_DomainFixing(t *testing.T) {
 	// Set up credentials for the test
-	os.Setenv("KRB_USERNAME", "test")
-	os.Setenv("KRB_PASSWORD", "test")
-	defer os.Unsetenv("KRB_USERNAME")
-	defer os.Unsetenv("KRB_PASSWORD")
+	os.Setenv("KRB5_USERNAME", "test")
+	os.Setenv("KRB5_PASSWORD", "test")
+	defer os.Unsetenv("KRB5_USERNAME")
+	defer os.Unsetenv("KRB5_PASSWORD")
 
 	cfg, _ := loadTestKrb5Config()
 	cl := client.NewWithPassword("test", "CERN.CH", "test", cfg, client.DisablePAFXFAST(true))


### PR DESCRIPTION
- Enable keytab authentication via --keytab flag or KRB5_KTNAME
- Implement strict priority for authentication methods (Password > Keytab > CCache > Default Keytab)
- Make KRB5_KTNAME usage fail fast on error instead of falling back
- Support --quiet flag in authentication module for cleaner output
- Improve consistency of principal normalization logic
- Update documentation with keytab usage details and examples

Fixes #71