### PR TITLE
build: add prek pre-commit hooks with conventional commits and linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,80 @@
+# golangci-lint configuration
+# See: https://golangci-lint.run/usage/configuration/
+
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  default: standard
+  enable:
+    # Error handling
+    - errcheck
+    - errorlint
+
+    # Style and formatting
+    - gofmt
+    - goimports
+
+    # Bugs and suspicious constructs
+    - govet
+    - staticcheck
+    - ineffassign
+
+    # Code complexity
+    - gocyclo
+    - cyclop
+
+    # Security
+    - gosec
+
+    # Performance
+    - prealloc
+
+    # Code quality
+    - unconvert
+    - unused
+    - unparam
+    - nakedret
+    - misspell
+    - gocritic
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
+  cyclop:
+    max-complexity: 15
+  goimports:
+    local-prefixes: github.com/clelange/cern-sso-cli
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - style
+      - performance
+    disabled-checks:
+      - ifElseChain
+  gosec:
+    excludes:
+      - G104 # Unhandled errors (too noisy for CLI apps)
+  nakedret:
+    max-func-lines: 30
+  misspell:
+    locale: UK
+
+issues:
+  exclude-dirs:
+    - passkey-helper
+  exclude-rules:
+    # Exclude some linters from running on tests
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - cyclop
+        - gosec
+        - errcheck
+    # Exclude generated files
+    - path: ".*_generated\\.go"
+      linters:
+        - all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+# See https://pre-commit.com for more information
+# Compatible with prek (https://github.com/j178/prek) - a faster drop-in replacement
+# Install: pip install pre-commit OR cargo install prek
+# Setup: pre-commit install (or prek install)
+
+repos:
+  # General file hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+
+  # Conventional commits
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: ['--strict']
+
+  # Go formatting
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+        args: ['-local', 'github.com/clelange/cern-sso-cli']
+      - id: go-mod-tidy
+      - id: go-vet-mod
+      - id: go-build-mod
+
+  # Go linting with golangci-lint
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.0.2
+    hooks:
+      - id: golangci-lint
+        args: ['--timeout=5m']
+
+  # Security scanning (local hook - requires gosec installed)
+  - repo: local
+    hooks:
+      - id: gosec
+        name: gosec
+        entry: gosec
+        args: ['-exclude-dir=passkey-helper', '-quiet', './...']
+        language: system
+        pass_filenames: false
+        types: [go]

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,6 +8,72 @@ This guide is for contributors who want to build, test, and develop cern-sso-cli
 - Make
 - Docker (for container builds, optional)
 
+## Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com) hooks to ensure code quality. We recommend using [prek](https://github.com/j178/prek), a faster Rust-based alternative.
+
+### Installation
+
+```bash
+# Install prek (recommended - faster, single binary)
+cargo install prek
+
+# Or install pre-commit (Python-based)
+pip install pre-commit
+
+# Install golangci-lint (required for lint hooks)
+# macOS
+brew install golangci-lint
+
+# Linux
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+```
+
+### Setup
+
+```bash
+# Install the git hooks
+prek install        # or: pre-commit install
+prek install --hook-type commit-msg  # Enable conventional commit checks
+```
+
+### Usage
+
+```bash
+# Run all hooks on staged files (automatic on git commit)
+prek run
+
+# Run all hooks on all files
+prek run --all-files
+
+# Run specific hook
+prek run golangci-lint --all-files
+
+# Run linting manually (without pre-commit)
+make lint
+```
+
+### Conventional Commits
+
+Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+
+**Examples:**
+```bash
+git commit -m "feat: add WebAuthn device selection"
+git commit -m "fix(auth): handle expired Kerberos tickets"
+git commit -m "docs: update installation instructions"
+```
+
 ## Build from Source
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE_NAME ?= cern-sso-cli
 
 LDFLAGS = -X main.version=$(VERSION)
 
-.PHONY: all build build-no-webauthn clean test-integration build-all build-no-webauthn download-certs docker-build docker-push
+.PHONY: all build build-no-webauthn clean test-integration lint build-all build-no-webauthn download-certs docker-build docker-push
 
 all: build
 
@@ -24,6 +24,9 @@ test-integration:
 
 test:
 	go test -v ./...
+
+lint:
+	golangci-lint run ./...
 
 clean:
 	rm -f $(BINARY_NAME)


### PR DESCRIPTION
- Add .pre-commit-config.yaml with hooks for:
  - Conventional commits enforcement
  - Go formatting (go-fmt, go-imports, go-mod-tidy)
  - Go linting (go-vet-mod, go-build-mod, golangci-lint)
  - Security scanning (gosec as local hook)
  - File hygiene (trailing whitespace, EOF, YAML validation)
- Add .golangci.yml with sensible defaults for CLI projects
- Add 'make lint' target to Makefile
- Update DEVELOPING.md with prek setup instructions

Closes #36