### PR TITLE
refactor(cmd): centralize command output rendering

### DIFF
--- a/cmd/cookie.go
+++ b/cmd/cookie.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -104,8 +103,7 @@ func runCookie(cmd *cobra.Command, args []string) error {
 			if ok, result, client := tryAuthCookies(cookieURL, cookieAuthHost, authCookies, cookieInsecure); ok {
 				logPrintln("Existing auth cookies worked. Skipping Kerberos authentication.")
 				output := saveCookiesFromAuth(client, cookieFile, cookieURL, cookieAuthHost, result)
-				printCookieOutput(output)
-				return nil
+				return printCookieOutput(output)
 			}
 			logPrintln("Auth cookies invalid or expired, falling back to Kerberos...")
 		}
@@ -131,12 +129,11 @@ func runCookie(cmd *cobra.Command, args []string) error {
 				if err := jar.Update(cookieFile, nil, targetDomain); err != nil {
 					logInfo("Warning: Failed to cleanup cookies: %v\n", err)
 				}
-				printCookieOutput(&CookieOutput{
+				return printCookieOutput(&CookieOutput{
 					File:  cookieFile,
 					Count: len(domainCookies),
 					User:  cookie.LoadUser(cookieFile),
 				})
-				return nil
 			}
 			logPrintln("Cookies expired or invalid. Authenticating...")
 		} else {
@@ -214,14 +211,11 @@ func saveCookiesFromAuth(client *auth.KerberosClient, filename, targetURL, authH
 }
 
 // printCookieOutput prints the cookie output, as JSON if --json flag is set.
-func printCookieOutput(output *CookieOutput) {
+func printCookieOutput(output *CookieOutput) error {
 	if output == nil {
-		return
+		return nil
 	}
-	if cookieJSON {
-		data, _ := json.Marshal(output)
-		fmt.Println(string(data))
-	}
+	return writeCommandOutput(cookieJSON, output)
 }
 
 // authenticateWithKerberos performs full Kerberos authentication flow.
@@ -232,6 +226,5 @@ func authenticateWithKerberos(targetURL, filename, authHost string, insecure boo
 	}
 
 	output := saveCookiesFromAuth(kerbClient, filename, targetURL, authHost, result)
-	printCookieOutput(output)
-	return nil
+	return printCookieOutput(output)
 }

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -64,23 +63,20 @@ func runDevice(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("device login failed: %w", err)
 	}
 
-	if deviceJSON {
-		output := DeviceOutput{
-			AccessToken:  token.AccessToken,
-			TokenType:    token.TokenType,
-			ExpiresIn:    token.ExpiresIn,
-			RefreshToken: token.RefreshToken,
-			Scope:        token.Scope,
-		}
-		data, _ := json.Marshal(output)
-		fmt.Println(string(data))
-	} else {
-		fmt.Println("Access Token:")
-		fmt.Println(token.AccessToken)
-		if token.RefreshToken != "" {
-			fmt.Println("\nRefresh Token:")
-			fmt.Println(token.RefreshToken)
-		}
+	return renderDeviceOutput(token)
+}
+
+func renderDeviceOutput(token *auth.TokenResponse) error {
+	lines := []string{"Access Token:", token.AccessToken}
+	if token.RefreshToken != "" {
+		lines = append(lines, "", "Refresh Token:", token.RefreshToken)
 	}
-	return nil
+
+	return writeCommandOutput(deviceJSON, DeviceOutput{
+		AccessToken:  token.AccessToken,
+		TokenType:    token.TokenType,
+		ExpiresIn:    token.ExpiresIn,
+		RefreshToken: token.RefreshToken,
+		Scope:        token.Scope,
+	}, lines...)
 }

--- a/cmd/harbor.go
+++ b/cmd/harbor.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -77,18 +76,13 @@ func runHarbor(cmd *cobra.Command, args []string) error {
 	}
 	logInfo("Authenticated as: %s (ID: %d)\n", secretResult.Username, secretResult.UserID)
 
-	// Output
-	if harborJSON {
-		output := HarborSecretOutput{
-			Username: secretResult.Username,
-			Secret:   secretResult.Secret,
-		}
-		data, _ := json.Marshal(output)
-		fmt.Println(string(data))
-	} else {
-		logInfo("Username: %s\n", secretResult.Username)
-		fmt.Println(secretResult.Secret)
-	}
+	logInfo("Username: %s\n", secretResult.Username)
+	return renderHarborOutput(secretResult.Username, secretResult.Secret)
+}
 
-	return nil
+func renderHarborOutput(username, secret string) error {
+	return writeCommandOutput(harborJSON, HarborSecretOutput{
+		Username: username,
+		Secret:   secret,
+	}, secret)
 }

--- a/cmd/openshift.go
+++ b/cmd/openshift.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -99,21 +98,18 @@ func runOpenShift(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Output
-	switch {
-	case openshiftJSON:
-		output := OpenShiftLoginOutput{
-			Command: loginResult.Command,
-			Token:   loginResult.Token,
-			Server:  loginResult.Server,
-		}
-		data, _ := json.Marshal(output)
-		fmt.Println(string(data))
-	case openshiftLoginCmd:
-		fmt.Println(loginResult.Command)
-	default:
-		fmt.Println(loginResult.Token)
+	return renderOpenShiftOutput(loginResult.Command, loginResult.Token, loginResult.Server)
+}
+
+func renderOpenShiftOutput(command, token, server string) error {
+	text := token
+	if openshiftLoginCmd {
+		text = command
 	}
 
-	return nil
+	return writeCommandOutput(openshiftJSON, OpenShiftLoginOutput{
+		Command: command,
+		Token:   token,
+		Server:  server,
+	}, text)
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func writeCommandOutput(jsonEnabled bool, jsonValue any, textLines ...string) error {
+	if quiet {
+		return nil
+	}
+
+	if jsonEnabled {
+		return json.NewEncoder(os.Stdout).Encode(jsonValue)
+	}
+
+	for _, line := range textLines {
+		if _, err := fmt.Fprintln(os.Stdout, line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/clelange/cern-sso-cli/pkg/auth"
+)
+
+func TestWriteCommandOutputQuietSuppressesOutput(t *testing.T) {
+	oldQuiet := quiet
+	quiet = true
+	defer func() { quiet = oldQuiet }()
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		if err := writeCommandOutput(true, map[string]string{"result": "ok"}, "visible"); err != nil {
+			t.Fatalf("writeCommandOutput failed: %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+}
+
+func TestRenderTokenOutputJSON(t *testing.T) {
+	oldQuiet := quiet
+	oldTokenJSON := tokenJSON
+	quiet = false
+	tokenJSON = true
+	defer func() {
+		quiet = oldQuiet
+		tokenJSON = oldTokenJSON
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := renderTokenOutput("token-123"); err != nil {
+			t.Fatalf("renderTokenOutput failed: %v", err)
+		}
+	})
+
+	var output TokenOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", stdout, err)
+	}
+
+	if output.AccessToken != "token-123" {
+		t.Fatalf("expected access token %q, got %q", "token-123", output.AccessToken)
+	}
+	if output.TokenType != "Bearer" {
+		t.Fatalf("expected token type %q, got %q", "Bearer", output.TokenType)
+	}
+}
+
+func TestRenderTokenOutputQuiet(t *testing.T) {
+	oldQuiet := quiet
+	oldTokenJSON := tokenJSON
+	quiet = true
+	tokenJSON = false
+	defer func() {
+		quiet = oldQuiet
+		tokenJSON = oldTokenJSON
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := renderTokenOutput("token-123"); err != nil {
+			t.Fatalf("renderTokenOutput failed: %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+}
+
+func TestRenderDeviceOutputText(t *testing.T) {
+	oldQuiet := quiet
+	oldDeviceJSON := deviceJSON
+	quiet = false
+	deviceJSON = false
+	defer func() {
+		quiet = oldQuiet
+		deviceJSON = oldDeviceJSON
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := renderDeviceOutput(&auth.TokenResponse{
+			AccessToken:  "access-123",
+			RefreshToken: "refresh-456",
+		}); err != nil {
+			t.Fatalf("renderDeviceOutput failed: %v", err)
+		}
+	})
+
+	expected := "Access Token:\naccess-123\n\nRefresh Token:\nrefresh-456\n"
+	if stdout != expected {
+		t.Fatalf("expected stdout %q, got %q", expected, stdout)
+	}
+}
+
+func TestRenderHarborOutputQuiet(t *testing.T) {
+	oldQuiet := quiet
+	oldHarborJSON := harborJSON
+	quiet = true
+	harborJSON = false
+	defer func() {
+		quiet = oldQuiet
+		harborJSON = oldHarborJSON
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := renderHarborOutput("alice", "secret-123"); err != nil {
+			t.Fatalf("renderHarborOutput failed: %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+}
+
+func TestRenderOpenShiftOutputLoginCommand(t *testing.T) {
+	oldQuiet := quiet
+	oldOpenShiftJSON := openshiftJSON
+	oldOpenShiftLoginCmd := openshiftLoginCmd
+	quiet = false
+	openshiftJSON = false
+	openshiftLoginCmd = true
+	defer func() {
+		quiet = oldQuiet
+		openshiftJSON = oldOpenShiftJSON
+		openshiftLoginCmd = oldOpenShiftLoginCmd
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := renderOpenShiftOutput(
+			"oc login --token=sha256~token --server=https://api.example:6443",
+			"sha256~token",
+			"https://api.example:6443",
+		); err != nil {
+			t.Fatalf("renderOpenShiftOutput failed: %v", err)
+		}
+	})
+
+	expected := "oc login --token=sha256~token --server=https://api.example:6443\n"
+	if stdout != expected {
+		t.Fatalf("expected stdout %q, got %q", expected, stdout)
+	}
+}
+
+func TestPrintCookieOutputJSON(t *testing.T) {
+	oldQuiet := quiet
+	oldCookieJSON := cookieJSON
+	quiet = false
+	cookieJSON = true
+	defer func() {
+		quiet = oldQuiet
+		cookieJSON = oldCookieJSON
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := printCookieOutput(&CookieOutput{
+			File:  "cookies.txt",
+			Count: 2,
+			User:  "alice@CERN.CH",
+		}); err != nil {
+			t.Fatalf("printCookieOutput failed: %v", err)
+		}
+	})
+
+	var output CookieOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", stdout, err)
+	}
+
+	if output.File != "cookies.txt" {
+		t.Fatalf("expected file %q, got %q", "cookies.txt", output.File)
+	}
+	if output.Count != 2 {
+		t.Fatalf("expected count %d, got %d", 2, output.Count)
+	}
+	if output.User != "alice@CERN.CH" {
+		t.Fatalf("expected user %q, got %q", "alice@CERN.CH", output.User)
+	}
+}
+
+func TestPrintCookieOutputDefaultModeIsSilent(t *testing.T) {
+	oldQuiet := quiet
+	oldCookieJSON := cookieJSON
+	quiet = false
+	cookieJSON = false
+	defer func() {
+		quiet = oldQuiet
+		cookieJSON = oldCookieJSON
+	}()
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := printCookieOutput(&CookieOutput{
+			File:  "cookies.txt",
+			Count: 2,
+		}); err != nil {
+			t.Fatalf("printCookieOutput failed: %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+}

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -77,15 +76,12 @@ func runToken(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get token: %w", err)
 	}
 
-	if tokenJSON {
-		output := TokenOutput{
-			AccessToken: token,
-			TokenType:   "Bearer",
-		}
-		data, _ := json.Marshal(output)
-		fmt.Println(string(data))
-	} else {
-		fmt.Println(token)
-	}
-	return nil
+	return renderTokenOutput(token)
+}
+
+func renderTokenOutput(token string) error {
+	return writeCommandOutput(tokenJSON, TokenOutput{
+		AccessToken: token,
+		TokenType:   "Bearer",
+	}, token)
 }


### PR DESCRIPTION
Add a shared command output helper for JSON, text, and quiet-mode handling so token, device, harbor, openshift, and cookie no longer implement their own stdout rendering paths.

Move each command to a small render function that builds its payload and lets the shared helper decide whether to emit JSON, plain text, or no output at all. This brings quiet mode in line with the documented behavior by suppressing successful result output as well as progress logs.

Add focused renderer tests covering quiet suppression, JSON output, the default text mode for token/device/openshift, and cookie output behavior so future command changes keep a stable output contract.