### PR TITLE
fix(auth): avoid mutating ccache env during auth

### DIFF
--- a/pkg/auth/ccache.go
+++ b/pkg/auth/ccache.go
@@ -39,21 +39,8 @@ func NormalizePrincipal(username string) string {
 // FindCCachePath locates the Kerberos credential cache file.
 // Returns empty string if no usable file-based cache is found.
 func FindCCachePath() string {
-	// Check KRB5CCNAME environment variable first
-	ccachePath := os.Getenv("KRB5CCNAME")
-	if ccachePath != "" {
-		// Handle FILE: prefix
-		if strings.HasPrefix(ccachePath, "FILE:") {
-			return strings.TrimPrefix(ccachePath, "FILE:")
-		}
-		// API: prefix (macOS) - not usable from pure Go
-		if strings.HasPrefix(ccachePath, "API:") {
-			return ""
-		}
-		// If it's a plain path, check if it exists
-		if _, err := os.Stat(ccachePath); err == nil { // #nosec G703
-			return ccachePath
-		}
+	if ccachePath := normalizeCCachePath(os.Getenv("KRB5CCNAME")); ccachePath != "" {
+		return ccachePath
 	}
 
 	// Try default paths based on platform
@@ -86,6 +73,20 @@ func FindCCachePath() string {
 	return ""
 }
 
+func normalizeCCachePath(ccachePath string) string {
+	if ccachePath == "" {
+		return ""
+	}
+	ccachePath = strings.TrimPrefix(ccachePath, "FILE:")
+	if strings.HasPrefix(ccachePath, "API:") {
+		return ""
+	}
+	if _, err := os.Stat(ccachePath); err == nil { // #nosec G703
+		return ccachePath
+	}
+	return ""
+}
+
 // getUID returns the current user's UID as a string.
 func getUID() string {
 	// Try UID environment variable first (might not be set)
@@ -102,6 +103,12 @@ func getUID() string {
 // Returns nil and an error if the cache is not found, invalid, or the TGT is expired.
 func NewClientFromCCache(cfg *config.Config) (*client.Client, error) {
 	ccachePath := FindCCachePath()
+	return NewClientFromCCachePath(cfg, ccachePath)
+}
+
+// NewClientFromCCachePath attempts to create a Kerberos client from a specific credential cache file.
+// Returns nil and an error if the cache path is empty, invalid, or the TGT is expired.
+func NewClientFromCCachePath(cfg *config.Config, ccachePath string) (*client.Client, error) {
 	if ccachePath == "" {
 		return nil, fmt.Errorf("no file-based credential cache found")
 	}

--- a/pkg/auth/kerberos_auth.go
+++ b/pkg/auth/kerberos_auth.go
@@ -9,6 +9,15 @@ import (
 	"github.com/jcmturner/gokrb5/v8/config"
 )
 
+var (
+	isMacOSAPICCacheFunc       = IsMacOSAPICCache
+	findCacheByUsernameFunc    = FindCacheByUsername
+	convertSpecificCacheToFile = ConvertSpecificCacheToFile
+	convertAPICacheToFile      = ConvertAPICacheToFile
+	newClientFromCCacheFunc    = NewClientFromCCache
+	newClientFromCCachePath    = NewClientFromCCachePath
+)
+
 // NewKerberosClient creates a new Kerberos client with automatic authentication.
 // This is a convenience wrapper that uses automatic authentication method selection.
 // krb5ConfigSource can be "embedded" (default), "system", or a file path.
@@ -41,23 +50,22 @@ func tryPasswordAuth(cfg *config.Config, username, password string) (*client.Cli
 // tryUserCacheAuth attempts to authenticate using a specific user's cache on macOS.
 // Returns the client and principal if successful, or an error if not found/failed.
 func tryUserCacheAuth(cfg *config.Config, username string) (*client.Client, string, error) {
-	if !IsMacOSAPICCache() {
+	if !isMacOSAPICCacheFunc() {
 		return nil, "", fmt.Errorf("not macOS API cache")
 	}
 
-	cacheInfo, err := FindCacheByUsername(username)
+	cacheInfo, err := findCacheByUsernameFunc(username)
 	if err != nil {
 		return nil, "", err // Includes list of available caches
 	}
 
 	// Convert API cache to file-based cache
-	filePath, err := ConvertSpecificCacheToFile(cacheInfo)
+	filePath, err := convertSpecificCacheToFile(cacheInfo)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to convert cache: %w", err)
 	}
 
-	_ = os.Setenv("KRB5CCNAME", filePath)
-	cl, err := NewClientFromCCache(cfg)
+	cl, err := newClientFromCCachePath(cfg, filePath)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load converted cache: %w", err)
 	}
@@ -70,18 +78,17 @@ func tryUserCacheAuth(cfg *config.Config, username string) (*client.Client, stri
 // Returns the client and extracted principal if successful.
 func tryDefaultCacheAuth(cfg *config.Config) (*client.Client, string, error) {
 	// Try file-based cache directly
-	cl, err := NewClientFromCCache(cfg)
+	cl, err := newClientFromCCacheFunc(cfg)
 	if err == nil {
 		username := extractUsernameFromClient(cl)
 		return cl, username, nil
 	}
 
 	// On macOS, try to convert API cache to file cache
-	if IsMacOSAPICCache() {
-		filePath, convErr := ConvertAPICacheToFile()
+	if isMacOSAPICCacheFunc() {
+		filePath, convErr := convertAPICacheToFile()
 		if convErr == nil {
-			_ = os.Setenv("KRB5CCNAME", filePath)
-			cl, err = NewClientFromCCache(cfg)
+			cl, err = newClientFromCCachePath(cfg, filePath)
 			if err == nil {
 				username := extractUsernameFromClient(cl)
 				return cl, username, nil

--- a/pkg/auth/kerberos_auth_test.go
+++ b/pkg/auth/kerberos_auth_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jcmturner/gokrb5/v8/client"
+	"github.com/jcmturner/gokrb5/v8/config"
+)
+
+func TestTryUserCacheAuthDoesNotMutateKRB5CCNAME(t *testing.T) {
+	cfg, err := loadTestKrb5Config()
+	if err != nil {
+		t.Fatalf("failed to load test config: %v", err)
+	}
+
+	oldIsMacOSAPICCacheFunc := isMacOSAPICCacheFunc
+	oldFindCacheByUsernameFunc := findCacheByUsernameFunc
+	oldConvertSpecificCacheToFile := convertSpecificCacheToFile
+	oldNewClientFromCCachePath := newClientFromCCachePath
+	defer func() {
+		isMacOSAPICCacheFunc = oldIsMacOSAPICCacheFunc
+		findCacheByUsernameFunc = oldFindCacheByUsernameFunc
+		convertSpecificCacheToFile = oldConvertSpecificCacheToFile
+		newClientFromCCachePath = oldNewClientFromCCachePath
+	}()
+
+	isMacOSAPICCacheFunc = func() bool { return true }
+	findCacheByUsernameFunc = func(username string) (*CacheInfo, error) {
+		return &CacheInfo{
+			Principal: NormalizePrincipal(username),
+			CacheName: "API:stub",
+		}, nil
+	}
+	convertSpecificCacheToFile = func(cacheInfo *CacheInfo) (string, error) {
+		return "/tmp/converted-cache", nil
+	}
+	newClientFromCCachePath = func(cfg *config.Config, path string) (*client.Client, error) {
+		if path != "/tmp/converted-cache" {
+			return nil, fmt.Errorf("unexpected cache path %q", path)
+		}
+		return &client.Client{}, nil
+	}
+
+	t.Setenv("KRB5CCNAME", "FILE:/tmp/original-cache")
+
+	_, _, err = tryUserCacheAuth(cfg, "alice")
+	if err != nil {
+		t.Fatalf("tryUserCacheAuth failed: %v", err)
+	}
+
+	if got := os.Getenv("KRB5CCNAME"); got != "FILE:/tmp/original-cache" {
+		t.Fatalf("expected KRB5CCNAME to remain unchanged, got %q", got)
+	}
+}
+
+func TestTryDefaultCacheAuthConvertedCacheDoesNotMutateKRB5CCNAME(t *testing.T) {
+	cfg, err := loadTestKrb5Config()
+	if err != nil {
+		t.Fatalf("failed to load test config: %v", err)
+	}
+
+	oldIsMacOSAPICCacheFunc := isMacOSAPICCacheFunc
+	oldConvertAPICacheToFile := convertAPICacheToFile
+	oldNewClientFromCCacheFunc := newClientFromCCacheFunc
+	oldNewClientFromCCachePath := newClientFromCCachePath
+	defer func() {
+		isMacOSAPICCacheFunc = oldIsMacOSAPICCacheFunc
+		convertAPICacheToFile = oldConvertAPICacheToFile
+		newClientFromCCacheFunc = oldNewClientFromCCacheFunc
+		newClientFromCCachePath = oldNewClientFromCCachePath
+	}()
+
+	isMacOSAPICCacheFunc = func() bool { return true }
+	convertAPICacheToFile = func() (string, error) {
+		return "/tmp/converted-default-cache", nil
+	}
+	newClientFromCCacheFunc = func(cfg *config.Config) (*client.Client, error) {
+		return nil, fmt.Errorf("no cache")
+	}
+	newClientFromCCachePath = func(cfg *config.Config, path string) (*client.Client, error) {
+		if path != "/tmp/converted-default-cache" {
+			return nil, fmt.Errorf("unexpected cache path %q", path)
+		}
+		return &client.Client{}, nil
+	}
+
+	t.Setenv("KRB5CCNAME", "FILE:/tmp/original-cache")
+
+	_, _, err = tryDefaultCacheAuth(cfg)
+	if err != nil {
+		t.Fatalf("tryDefaultCacheAuth failed: %v", err)
+	}
+
+	if got := os.Getenv("KRB5CCNAME"); got != "FILE:/tmp/original-cache" {
+		t.Fatalf("expected KRB5CCNAME to remain unchanged, got %q", got)
+	}
+}


### PR DESCRIPTION
Load converted credential caches through an explicit cache-path helper instead of setting KRB5CCNAME and then reading it back through the default ccache discovery path.

Update the user-cache and default-cache auth branches to pass the converted cache file directly into NewClientFromCCachePath so cache selection no longer changes process-global state as a side effect.

Add focused auth tests that stub the converted-cache branches and verify KRB5CCNAME remains unchanged after both user-specific and default ccache authentication attempts.