### PR TITLE
refactor(http): extract shared client factory

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -1,0 +1,69 @@
+package httpclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/cookiejar"
+	"time"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// Config configures a shared HTTP client.
+type Config struct {
+	Timeout        time.Duration
+	VerifyCert     bool
+	Jar            http.CookieJar
+	CheckRedirect  func(req *http.Request, via []*http.Request) error
+	Transport      http.RoundTripper
+	RootCAs        *x509.CertPool
+	ForceTLSConfig bool
+}
+
+// TransportConfig configures a shared HTTP transport.
+type TransportConfig struct {
+	VerifyCert     bool
+	RootCAs        *x509.CertPool
+	ForceTLSConfig bool
+}
+
+// New creates an HTTP client with consistent timeout and TLS settings.
+func New(cfg Config) *http.Client {
+	transport := cfg.Transport
+	if transport == nil {
+		transport = NewTransport(TransportConfig{
+			VerifyCert:     cfg.VerifyCert,
+			RootCAs:        cfg.RootCAs,
+			ForceTLSConfig: cfg.ForceTLSConfig,
+		})
+	}
+
+	return &http.Client{
+		Jar:           cfg.Jar,
+		Transport:     transport,
+		Timeout:       cfg.Timeout,
+		CheckRedirect: cfg.CheckRedirect,
+	}
+}
+
+// NewTransport creates an HTTP transport with consistent TLS settings.
+func NewTransport(cfg TransportConfig) *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if !cfg.VerifyCert || cfg.RootCAs != nil || cfg.ForceTLSConfig {
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: !cfg.VerifyCert, // #nosec G402
+		}
+		if cfg.RootCAs != nil {
+			tlsConfig.RootCAs = cfg.RootCAs
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
+
+	return transport
+}
+
+// NewJar creates a cookie jar with a public suffix list.
+func NewJar() (*cookiejar.Jar, error) {
+	return cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+}

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -1,0 +1,126 @@
+package httpclient
+
+import (
+	"crypto/x509"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewTransport(t *testing.T) {
+	rootCAs := x509.NewCertPool()
+
+	tests := []struct {
+		name           string
+		cfg            TransportConfig
+		wantTLSConfig  bool
+		wantSkipVerify bool
+		wantRootCAs    *x509.CertPool
+	}{
+		{
+			name: "default verified transport",
+			cfg: TransportConfig{
+				VerifyCert: true,
+			},
+			wantTLSConfig: false,
+		},
+		{
+			name: "insecure transport",
+			cfg: TransportConfig{
+				VerifyCert: false,
+			},
+			wantTLSConfig:  true,
+			wantSkipVerify: true,
+		},
+		{
+			name: "custom root CAs",
+			cfg: TransportConfig{
+				VerifyCert: true,
+				RootCAs:    rootCAs,
+			},
+			wantTLSConfig:  true,
+			wantSkipVerify: false,
+			wantRootCAs:    rootCAs,
+		},
+		{
+			name: "forced TLS config",
+			cfg: TransportConfig{
+				VerifyCert:     true,
+				ForceTLSConfig: true,
+			},
+			wantTLSConfig:  true,
+			wantSkipVerify: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewTransport(tt.cfg)
+			if transport == nil {
+				t.Fatal("expected transport")
+			}
+
+			if !tt.wantTLSConfig {
+				if transport.TLSClientConfig != nil {
+					if transport.TLSClientConfig.InsecureSkipVerify {
+						t.Fatal("expected verified transport to keep InsecureSkipVerify disabled")
+					}
+					if transport.TLSClientConfig.RootCAs != nil {
+						t.Fatal("expected verified transport to keep custom RootCAs unset")
+					}
+				}
+				return
+			}
+			if transport.TLSClientConfig == nil {
+				t.Fatal("expected TLSClientConfig to be set")
+			}
+
+			if transport.TLSClientConfig.InsecureSkipVerify != tt.wantSkipVerify {
+				t.Fatalf("InsecureSkipVerify = %v, want %v", transport.TLSClientConfig.InsecureSkipVerify, tt.wantSkipVerify)
+			}
+			if transport.TLSClientConfig.RootCAs != tt.wantRootCAs {
+				t.Fatalf("RootCAs = %p, want %p", transport.TLSClientConfig.RootCAs, tt.wantRootCAs)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	jar, err := NewJar()
+	if err != nil {
+		t.Fatalf("NewJar failed: %v", err)
+	}
+
+	checkRedirect := func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	client := New(Config{
+		Timeout:        15 * time.Second,
+		VerifyCert:     false,
+		Jar:            jar,
+		CheckRedirect:  checkRedirect,
+		ForceTLSConfig: true,
+	})
+
+	if client.Timeout != 15*time.Second {
+		t.Fatalf("Timeout = %v, want %v", client.Timeout, 15*time.Second)
+	}
+	if client.Jar != jar {
+		t.Fatal("expected client jar to be preserved")
+	}
+	if client.CheckRedirect == nil {
+		t.Fatal("expected CheckRedirect to be set")
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("expected TLSClientConfig to be set")
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected insecure TLS config")
+	}
+}

--- a/pkg/auth/kerberos_client.go
+++ b/pkg/auth/kerberos_client.go
@@ -1,17 +1,16 @@
 package auth
 
 import (
-	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"runtime"
 
 	"github.com/jcmturner/gokrb5/v8/client"
 	"github.com/jcmturner/gokrb5/v8/spnego"
-	"golang.org/x/net/publicsuffix"
 
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
 	"github.com/clelange/cern-sso-cli/pkg/auth/certs"
 )
 
@@ -51,7 +50,7 @@ func newTestKerberosClient(cl *client.Client, verifyCert bool) (*KerberosClient,
 
 // newKerberosClientFromKrbClientWithUser creates a KerberosClient from an existing gokrb5 client with a username.
 func newKerberosClientFromKrbClientWithUser(cl *client.Client, version string, verifyCert bool, username string) (*KerberosClient, error) {
-	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	jar, err := httpclient.NewJar()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cookie jar: %w", err)
 	}
@@ -64,38 +63,35 @@ func newKerberosClientFromKrbClientWithUser(cl *client.Client, version string, v
 		username:         username,
 	}
 
-	// Build TLS config
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: !verifyCert, // #nosec G402
-	}
-
+	var certPool *x509.CertPool
 	// When verifying certs, use system certs plus embedded CERN CA certificates
 	if verifyCert {
-		certPool, err := certs.GetSystemWithCERNCertPool()
+		certPool, err = certs.GetSystemWithCERNCertPool()
 		if err != nil {
 			// Fall back to just system certs if CERN certs fail to load
 			// This shouldn't happen with embedded certs, but be defensive
 			certPool = nil
 		}
-		tlsConfig.RootCAs = certPool
 	}
 
 	// Create a custom transport that intercepts cookies from responses
 	customTransport := &cookieInterceptTransport{
-		base: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		base: httpclient.NewTransport(httpclient.TransportConfig{
+			VerifyCert:     verifyCert,
+			RootCAs:        certPool,
+			ForceTLSConfig: true,
+		}),
 		client: kc,
 	}
 
-	httpClient := &http.Client{
+	httpClient := httpclient.New(httpclient.Config{
 		Jar:       jar,
 		Transport: customTransport,
 		Timeout:   oidcHTTPTimeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse // Don't follow redirects automatically
 		},
-	}
+	})
 
 	kc.httpClient = httpClient
 	return kc, nil

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -13,6 +12,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
 )
 
 const oidcHTTPTimeout = 60 * time.Second
@@ -117,12 +118,10 @@ func DeviceAuthorizationFlow(cfg OIDCConfig) (*TokenResponse, error) {
 		cfg.AuthHostname, cfg.AuthRealm,
 	)
 
-	client := &http.Client{
-		Timeout: oidcHTTPTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.VerifyCert}, // #nosec G402
-		},
-	}
+	client := httpclient.New(httpclient.Config{
+		Timeout:    oidcHTTPTimeout,
+		VerifyCert: cfg.VerifyCert,
+	})
 
 	resp, err := client.PostForm(deviceURL, url.Values{
 		"client_id":             {cfg.ClientID},
@@ -248,12 +247,10 @@ func TokenExchange(cfg OIDCConfig, subjectToken, audience string) (*TokenRespons
 		cfg.AuthHostname, cfg.AuthRealm,
 	)
 
-	client := &http.Client{
-		Timeout: oidcHTTPTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.VerifyCert}, // #nosec G402
-		},
-	}
+	client := httpclient.New(httpclient.Config{
+		Timeout:    oidcHTTPTimeout,
+		VerifyCert: cfg.VerifyCert,
+	})
 
 	resp, err := client.PostForm(tokenURL, url.Values{
 		"client_id":            {cfg.ClientID},

--- a/pkg/cookie/jar.go
+++ b/pkg/cookie/jar.go
@@ -2,7 +2,6 @@ package cookie
 
 import (
 	"bufio"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
@@ -13,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/publicsuffix"
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
 )
 
 const verifyHTTPTimeout = 30 * time.Second
@@ -77,19 +76,17 @@ func VerifyCookies(targetURL, authHost string, cookies []*http.Cookie, verifyCer
 		}
 	}
 
-	client := &http.Client{
-		Jar:     jar,
-		Timeout: verifyHTTPTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyCert}, // #nosec G402
-		},
+	client := httpclient.New(httpclient.Config{
+		Jar:        jar,
+		Timeout:    verifyHTTPTimeout,
+		VerifyCert: verifyCert,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Host == authHost {
 				return http.ErrUseLastResponse
 			}
 			return nil
 		},
-	}
+	})
 
 	resp, err := client.Get(targetURL)
 	if err != nil {
@@ -131,7 +128,7 @@ type Jar struct {
 
 // NewJar creates a new cookie jar.
 func NewJar() (*Jar, error) {
-	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	jar, err := httpclient.NewJar()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/harbor/service.go
+++ b/pkg/services/harbor/service.go
@@ -1,12 +1,13 @@
 package harbor
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
 )
 
 const httpTimeout = 30 * time.Second
@@ -34,12 +35,10 @@ type cliSecretResponse struct {
 
 // FetchCLISecret fetches the Harbor CLI secret using an authenticated SSO cookie set.
 func FetchCLISecret(baseURL string, cookies []*http.Cookie, verifyCerts bool) (*SecretResult, error) {
-	client := &http.Client{Timeout: httpTimeout}
-	if !verifyCerts {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
-		}
-	}
+	client := httpclient.New(httpclient.Config{
+		Timeout:    httpTimeout,
+		VerifyCert: verifyCerts,
+	})
 
 	currentUser, err := fetchCurrentUser(client, baseURL, cookies)
 	if err != nil {

--- a/pkg/services/openshift/service.go
+++ b/pkg/services/openshift/service.go
@@ -1,16 +1,16 @@
 package openshift
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
 )
 
 const httpTimeout = 30 * time.Second
@@ -36,21 +36,16 @@ func FetchLoginCommand(
 	verifyCerts bool,
 	logf LogFunc,
 ) (*LoginCommandResult, error) {
-	jar, err := cookiejar.New(nil)
+	jar, err := httpclient.NewJar()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cookie jar: %w", err)
 	}
 
-	transport := &http.Transport{}
-	if !verifyCerts {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
-	}
-
-	client := &http.Client{
-		Jar:       jar,
-		Transport: transport,
-		Timeout:   httpTimeout,
-	}
+	client := httpclient.New(httpclient.Config{
+		Jar:        jar,
+		Timeout:    httpTimeout,
+		VerifyCert: verifyCerts,
+	})
 
 	oauthURL, err := url.Parse(oauthBaseURL)
 	if err != nil {

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
 	"github.com/clelange/cern-sso-cli/pkg/auth"
 )
 
@@ -49,7 +50,7 @@ func CheckForUpdate() (*ReleaseInfo, error) {
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("User-Agent", "cern-sso-cli")
 
-	client := &http.Client{Timeout: updateAPITimeout}
+	client := httpclient.New(httpclient.Config{Timeout: updateAPITimeout, VerifyCert: true})
 	resp, err := client.Do(req) // #nosec G704
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch release info: %w", err)
@@ -173,7 +174,7 @@ func GetAssetForCurrentPlatform(release *ReleaseInfo) (binaryURL, checksumURL st
 //
 //nolint:cyclop // Download with progress tracking and chunked reading
 func DownloadBinary(url string, progress func(downloaded, total int64)) ([]byte, error) {
-	client := &http.Client{Timeout: updateDownloadTimeout}
+	client := httpclient.New(httpclient.Config{Timeout: updateDownloadTimeout, VerifyCert: true})
 	resp, err := client.Get(url) // #nosec G107
 	if err != nil {
 		return nil, fmt.Errorf("failed to download binary: %w", err)
@@ -219,7 +220,7 @@ func DownloadBinary(url string, progress func(downloaded, total int64)) ([]byte,
 
 // FetchChecksums downloads and parses the checksums file.
 func FetchChecksums(url string) (map[string]string, error) {
-	client := &http.Client{Timeout: updateAPITimeout}
+	client := httpclient.New(httpclient.Config{Timeout: updateAPITimeout, VerifyCert: true})
 	resp, err := client.Get(url) // #nosec G107
 	if err != nil {
 		return nil, fmt.Errorf("failed to download checksums: %w", err)


### PR DESCRIPTION
Add an internal httpclient package that centralizes timeout, TLS verification, redirect handling, and cookie-jar construction for ad-hoc HTTP clients.

Use the shared factory across OIDC flows, cookie verification, Harbor and OpenShift service calls, update checks/downloads, and the Kerberos session client transport setup. Include focused tests for transport and client configuration so insecure mode, custom roots, and shared defaults stay consistent.