### PR TITLE
refactor(cmd): centralize status exit handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -64,13 +65,38 @@ This is the Go equivalent of auth-get-sso-cookie. It allows you to:
 	SilenceUsage: true,
 }
 
+type exitCodeError struct {
+	code int
+}
+
+func (e *exitCodeError) Error() string {
+	return ""
+}
+
+func (e *exitCodeError) ExitCode() int {
+	return e.code
+}
+
+func exitCodeForError(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	return 1
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	// Update version in case it was set after init
 	rootCmd.Version = version
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
+		os.Exit(exitCodeForError(err))
 	}
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -66,32 +67,26 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if quiet {
-		// In quiet mode, exit with code based on cookie validity
-		if verified {
-			// If verification was requested, use actual verification result
-			if verifiedValid {
-				os.Exit(0)
-			} else {
-				os.Exit(1)
-			}
-		} else {
-			// Without verification, check expiry times only
-			now := time.Now()
-			hasValidCookies := false
-			for _, c := range cookies {
-				if c.Expires.IsZero() || c.Expires.After(now) {
-					hasValidCookies = true
-					break
-				}
-			}
-			if hasValidCookies {
-				os.Exit(0)
-			} else {
-				os.Exit(1)
-			}
+		if statusIsValid(cookies, verified, verifiedValid, time.Now()) {
+			return nil
 		}
+		return &exitCodeError{code: 1}
 	}
 
 	cookie.PrintStatus(cookies, statusJSON, verified, verifiedValid, os.Stdout)
 	return nil
+}
+
+func statusIsValid(cookies []*http.Cookie, verified bool, verifiedValid bool, now time.Time) bool {
+	if verified {
+		return verifiedValid
+	}
+
+	for _, c := range cookies {
+		if c.Expires.IsZero() || c.Expires.After(now) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExitCodeForErrorUsesCustomExitCode(t *testing.T) {
+	if code := exitCodeForError(&exitCodeError{code: 7}); code != 7 {
+		t.Fatalf("expected exit code %d, got %d", 7, code)
+	}
+}
+
+func TestStatusIsValidUsesVerificationResult(t *testing.T) {
+	cookies := []*http.Cookie{
+		{Name: "auth", Expires: time.Now().Add(1 * time.Hour)},
+	}
+
+	if statusIsValid(cookies, true, false, time.Now()) {
+		t.Fatal("expected failed verification to mark cookies invalid")
+	}
+	if !statusIsValid(cookies, true, true, time.Now()) {
+		t.Fatal("expected successful verification to mark cookies valid")
+	}
+}
+
+func TestStatusIsValidUsesExpiryWithoutVerification(t *testing.T) {
+	now := time.Now()
+
+	if !statusIsValid([]*http.Cookie{{Name: "session"}}, false, false, now) {
+		t.Fatal("expected session cookie to be treated as valid")
+	}
+	if !statusIsValid([]*http.Cookie{{Name: "future", Expires: now.Add(1 * time.Hour)}}, false, false, now) {
+		t.Fatal("expected future cookie to be treated as valid")
+	}
+	if statusIsValid([]*http.Cookie{{Name: "expired", Expires: now.Add(-1 * time.Hour)}}, false, false, now) {
+		t.Fatal("expected expired cookies to be treated as invalid")
+	}
+}
+
+func TestRunStatusQuietReturnsExitCodeErrorForExpiredCookies(t *testing.T) {
+	oldQuiet := quiet
+	oldStatusFile := statusFile
+	oldStatusURL := statusURL
+	oldStatusJSON := statusJSON
+	defer func() {
+		quiet = oldQuiet
+		statusFile = oldStatusFile
+		statusURL = oldStatusURL
+		statusJSON = oldStatusJSON
+	}()
+
+	quiet = true
+	statusURL = ""
+	statusJSON = false
+	statusFile = writeStatusCookieFile(t, time.Now().Add(-1*time.Hour))
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		err := runStatus(statusCmd, nil)
+		if exitCodeForError(err) != 1 {
+			t.Fatalf("expected exit code %d, got %d (err=%v)", 1, exitCodeForError(err), err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+}
+
+func TestRunStatusQuietSucceedsForValidCookies(t *testing.T) {
+	oldQuiet := quiet
+	oldStatusFile := statusFile
+	oldStatusURL := statusURL
+	oldStatusJSON := statusJSON
+	defer func() {
+		quiet = oldQuiet
+		statusFile = oldStatusFile
+		statusURL = oldStatusURL
+		statusJSON = oldStatusJSON
+	}()
+
+	quiet = true
+	statusURL = ""
+	statusJSON = false
+	statusFile = writeStatusCookieFile(t, time.Now().Add(1*time.Hour))
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+}
+
+func writeStatusCookieFile(t *testing.T, expires time.Time) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "cookies.txt")
+	content := strings.Join([]string{
+		"# Netscape HTTP Cookie File",
+		".example.com\tTRUE\t/\tTRUE\t" + formatUnix(expires) + "\tAUTH_SESSION\tvalue",
+		"",
+	}, "\n")
+
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write cookie file: %v", err)
+	}
+
+	return path
+}
+
+func formatUnix(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
+}


### PR DESCRIPTION
Move command-specific exit handling into the shared Execute path by introducing a small exit-code error helper in cmd/root.go.

Update the status command to return a quiet-mode failure result instead of calling os.Exit inside RunE, and add focused tests for exit-code translation plus quiet status success and failure cases.