### PR TITLE
refactor(auth): move device prompt rendering to cmd

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -55,10 +56,16 @@ func runDevice(cmd *cobra.Command, args []string) error {
 		AuthRealm:    deviceRealm,
 		ClientID:     deviceClientID,
 		VerifyCert:   !deviceInsecure,
-		Quiet:        quiet,
 	}
 
-	token, err := auth.DeviceAuthorizationFlow(cfg)
+	session, err := auth.StartDeviceAuthorization(cfg)
+	if err != nil {
+		return fmt.Errorf("device login failed: %w", err)
+	}
+
+	renderDeviceInstructions(session.Prompt)
+
+	token, err := session.WaitForToken()
 	if err != nil {
 		return fmt.Errorf("device login failed: %w", err)
 	}
@@ -79,4 +86,15 @@ func renderDeviceOutput(token *auth.TokenResponse) error {
 		RefreshToken: token.RefreshToken,
 		Scope:        token.Scope,
 	}, lines...)
+}
+
+func renderDeviceInstructions(prompt auth.DeviceAuthorizationPrompt) {
+	_, _ = fmt.Fprintln(os.Stderr, "CERN Single Sign-On")
+	_, _ = fmt.Fprintln(os.Stderr)
+	_, _ = fmt.Fprintf(os.Stderr, "On your tablet, phone or computer, go to:\n    %s\n", prompt.VerificationURI)
+	_, _ = fmt.Fprintf(os.Stderr, "and enter the following code:\n    %s\n\n", prompt.UserCode)
+	_, _ = fmt.Fprintf(os.Stderr, "You may also open the following link directly:\n    %s\n\n", prompt.VerificationURIComplete)
+	if !quiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Waiting for login...")
+	}
 }

--- a/cmd/device_test.go
+++ b/cmd/device_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/clelange/cern-sso-cli/pkg/auth"
+)
+
+func TestRenderDeviceInstructionsIncludesWaitingMessageByDefault(t *testing.T) {
+	oldQuiet := quiet
+	quiet = false
+	defer func() { quiet = oldQuiet }()
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		renderDeviceInstructions(auth.DeviceAuthorizationPrompt{
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://auth.example/verify",
+			VerificationURIComplete: "https://auth.example/verify?user_code=ABCD-EFGH",
+		})
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	for _, want := range []string{
+		"CERN Single Sign-On",
+		"https://auth.example/verify",
+		"ABCD-EFGH",
+		"https://auth.example/verify?user_code=ABCD-EFGH",
+		"Waiting for login...",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected stderr to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestRenderDeviceInstructionsOmitsWaitingMessageInQuietMode(t *testing.T) {
+	oldQuiet := quiet
+	quiet = true
+	defer func() { quiet = oldQuiet }()
+
+	_, stderr := captureStdoutStderr(t, func() {
+		renderDeviceInstructions(auth.DeviceAuthorizationPrompt{
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://auth.example/verify",
+			VerificationURIComplete: "https://auth.example/verify?user_code=ABCD-EFGH",
+		})
+	})
+
+	if strings.Contains(stderr, "Waiting for login...") {
+		t.Fatalf("expected quiet mode to omit waiting message, got %q", stderr)
+	}
+	for _, want := range []string{"CERN Single Sign-On", "https://auth.example/verify", "ABCD-EFGH"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected stderr to contain %q, got %q", want, stderr)
+		}
+	}
+}

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -67,7 +67,6 @@ func runToken(cmd *cobra.Command, args []string) error {
 		ClientID:     tokenClientID,
 		RedirectURI:  tokenURL,
 		VerifyCert:   !tokenInsecure,
-		Quiet:        quiet,
 	}
 
 	logPrintln("Getting access token...")

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -25,7 +24,6 @@ type OIDCConfig struct {
 	ClientID     string
 	RedirectURI  string
 	VerifyCert   bool
-	Quiet        bool
 }
 
 // TokenResponse represents an OIDC token response.
@@ -36,6 +34,30 @@ type TokenResponse struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 	Scope        string `json:"scope,omitempty"`
 }
+
+// DeviceAuthorizationPrompt contains the user-facing details needed to complete device login.
+type DeviceAuthorizationPrompt struct {
+	UserCode                string
+	VerificationURI         string
+	VerificationURIComplete string
+}
+
+// DeviceAuthorizationSession tracks device authorization state while polling for a token.
+type DeviceAuthorizationSession struct {
+	Prompt       DeviceAuthorizationPrompt
+	client       *http.Client
+	clientID     string
+	codeVerifier string
+	deviceCode   string
+	tokenURL     string
+	pollInterval time.Duration
+	expiresAt    time.Time
+}
+
+var (
+	oidcTimeNow = time.Now
+	oidcSleep   = time.Sleep
+)
 
 // AuthorizationCodeFlow performs the OAuth2 Authorization Code flow with Kerberos.
 func AuthorizationCodeFlow(kerbClient *KerberosClient, cfg OIDCConfig) (string, error) {
@@ -104,10 +126,10 @@ func AuthorizationCodeFlow(kerbClient *KerberosClient, cfg OIDCConfig) (string, 
 	return tokenResp.AccessToken, nil
 }
 
-// DeviceAuthorizationFlow performs the OAuth2 Device Authorization Grant flow.
+// StartDeviceAuthorization initializes the OAuth2 Device Authorization Grant flow.
 //
 //nolint:cyclop // OAuth device flow with polling and multiple error conditions
-func DeviceAuthorizationFlow(cfg OIDCConfig) (*TokenResponse, error) {
+func StartDeviceAuthorization(cfg OIDCConfig) (*DeviceAuthorizationSession, error) {
 	// Generate PKCE values
 	codeVerifier := generateCodeVerifier()
 	codeChallenge := generateCodeChallenge(codeVerifier)
@@ -154,16 +176,6 @@ func DeviceAuthorizationFlow(cfg OIDCConfig) (*TokenResponse, error) {
 		return nil, err
 	}
 
-	// Print instructions (even in quiet mode - user needs them to complete auth)
-	_, _ = fmt.Fprintln(os.Stderr, "CERN Single Sign-On")
-	_, _ = fmt.Fprintln(os.Stderr)
-	_, _ = fmt.Fprintf(os.Stderr, "On your tablet, phone or computer, go to:\n    %s\n", deviceResp.VerificationURI)
-	_, _ = fmt.Fprintf(os.Stderr, "and enter the following code:\n    %s\n\n", deviceResp.UserCode)
-	_, _ = fmt.Fprintf(os.Stderr, "You may also open the following link directly:\n    %s\n\n", deviceResp.VerificationURIComplete)
-	if !cfg.Quiet {
-		_, _ = fmt.Fprintln(os.Stderr, "Waiting for login...")
-	}
-
 	// Set up polling with timeout
 	tokenURL := fmt.Sprintf(
 		"https://%s/auth/realms/%s/protocol/openid-connect/token",
@@ -176,21 +188,51 @@ func DeviceAuthorizationFlow(cfg OIDCConfig) (*TokenResponse, error) {
 	}
 
 	// Calculate expiry time
-	expiresAt := time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
+	expiresAt := oidcTimeNow().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
 
+	return &DeviceAuthorizationSession{
+		Prompt: DeviceAuthorizationPrompt{
+			UserCode:                deviceResp.UserCode,
+			VerificationURI:         deviceResp.VerificationURI,
+			VerificationURIComplete: deviceResp.VerificationURIComplete,
+		},
+		client:       client,
+		clientID:     cfg.ClientID,
+		codeVerifier: codeVerifier,
+		deviceCode:   deviceResp.DeviceCode,
+		tokenURL:     tokenURL,
+		pollInterval: pollInterval,
+		expiresAt:    expiresAt,
+	}, nil
+}
+
+// DeviceAuthorizationFlow performs the OAuth2 Device Authorization Grant flow.
+func DeviceAuthorizationFlow(cfg OIDCConfig) (*TokenResponse, error) {
+	session, err := StartDeviceAuthorization(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return session.WaitForToken()
+}
+
+// WaitForToken polls the token endpoint until device login completes or expires.
+//
+//nolint:cyclop // Device polling must handle multiple OAuth error branches and retry states.
+func (s *DeviceAuthorizationSession) WaitForToken() (*TokenResponse, error) {
 	for {
 		// Check if expired
-		if time.Now().After(expiresAt) {
+		if oidcTimeNow().After(s.expiresAt) {
 			return nil, &LoginError{Message: "device authorization expired - user did not complete login in time"}
 		}
 
-		time.Sleep(pollInterval)
+		oidcSleep(s.pollInterval)
 
-		resp, err := client.PostForm(tokenURL, url.Values{
-			"client_id":     {cfg.ClientID},
+		resp, err := s.client.PostForm(s.tokenURL, url.Values{
+			"client_id":     {s.clientID},
 			"grant_type":    {"urn:ietf:params:oauth:grant-type:device_code"},
-			"device_code":   {deviceResp.DeviceCode},
-			"code_verifier": {codeVerifier},
+			"device_code":   {s.deviceCode},
+			"code_verifier": {s.codeVerifier},
 		})
 		if err != nil {
 			// Network error - retry
@@ -224,7 +266,7 @@ func DeviceAuthorizationFlow(cfg OIDCConfig) (*TokenResponse, error) {
 			continue
 		case "slow_down":
 			// Server asks us to slow down - increase interval by 5 seconds (RFC 8628)
-			pollInterval += 5 * time.Second
+			s.pollInterval += 5 * time.Second
 			continue
 		case "expired_token":
 			return nil, &LoginError{Message: "device authorization expired"}

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestStartDeviceAuthorizationReturnsPrompt(t *testing.T) {
+	var gotChallengeMethod string
+	var gotClientID string
+	var gotChallenge string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/realms/cern/protocol/openid-connect/auth/device" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+		gotClientID = r.Form.Get("client_id")
+		gotChallengeMethod = r.Form.Get("code_challenge_method")
+		gotChallenge = r.Form.Get("code_challenge")
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":               "device-code-123",
+			"user_code":                 "ABCD-EFGH",
+			"verification_uri":          "https://auth.example/verify",
+			"verification_uri_complete": "https://auth.example/verify?user_code=ABCD-EFGH",
+			"expires_in":                600,
+			"interval":                  9,
+		})
+	}))
+	defer server.Close()
+
+	cfg := newOIDCTestConfig(t, server.URL)
+	session, err := StartDeviceAuthorization(cfg)
+	if err != nil {
+		t.Fatalf("StartDeviceAuthorization failed: %v", err)
+	}
+
+	if gotClientID != cfg.ClientID {
+		t.Fatalf("expected client_id %q, got %q", cfg.ClientID, gotClientID)
+	}
+	if gotChallengeMethod != "S256" {
+		t.Fatalf("expected code_challenge_method %q, got %q", "S256", gotChallengeMethod)
+	}
+	if gotChallenge == "" {
+		t.Fatal("expected non-empty code_challenge")
+	}
+	if session.Prompt.UserCode != "ABCD-EFGH" {
+		t.Fatalf("expected user code %q, got %q", "ABCD-EFGH", session.Prompt.UserCode)
+	}
+	if session.Prompt.VerificationURI != "https://auth.example/verify" {
+		t.Fatalf("expected verification URI %q, got %q", "https://auth.example/verify", session.Prompt.VerificationURI)
+	}
+	if session.Prompt.VerificationURIComplete != "https://auth.example/verify?user_code=ABCD-EFGH" {
+		t.Fatalf("expected complete verification URI %q, got %q", "https://auth.example/verify?user_code=ABCD-EFGH", session.Prompt.VerificationURIComplete)
+	}
+	if session.pollInterval != 9*time.Second {
+		t.Fatalf("expected poll interval %v, got %v", 9*time.Second, session.pollInterval)
+	}
+}
+
+func TestDeviceAuthorizationSessionWaitForToken(t *testing.T) {
+	origOIDCTimeNow := oidcTimeNow
+	origOIDCSleep := oidcSleep
+	defer func() {
+		oidcTimeNow = origOIDCTimeNow
+		oidcSleep = origOIDCSleep
+	}()
+
+	currentTime := time.Unix(1_700_000_000, 0)
+	oidcTimeNow = func() time.Time { return currentTime }
+
+	var sleepCalls []time.Duration
+	oidcSleep = func(d time.Duration) {
+		sleepCalls = append(sleepCalls, d)
+	}
+
+	var tokenRequests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/realms/cern/protocol/openid-connect/auth/device":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "device-code-123",
+				"user_code":                 "ABCD-EFGH",
+				"verification_uri":          "https://auth.example/verify",
+				"verification_uri_complete": "https://auth.example/verify?user_code=ABCD-EFGH",
+				"expires_in":                600,
+				"interval":                  1,
+			})
+		case "/auth/realms/cern/protocol/openid-connect/token":
+			tokenRequests++
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("failed to parse token form: %v", err)
+			}
+			if r.Form.Get("client_id") != "device-client" {
+				t.Fatalf("expected client_id %q, got %q", "device-client", r.Form.Get("client_id"))
+			}
+			if r.Form.Get("device_code") != "device-code-123" {
+				t.Fatalf("expected device_code %q, got %q", "device-code-123", r.Form.Get("device_code"))
+			}
+			if r.Form.Get("code_verifier") == "" {
+				t.Fatal("expected non-empty code_verifier")
+			}
+
+			if tokenRequests == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error": "authorization_pending",
+				})
+				return
+			}
+
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "access-123",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"refresh_token": "refresh-456",
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	session, err := StartDeviceAuthorization(newOIDCTestConfig(t, server.URL))
+	if err != nil {
+		t.Fatalf("StartDeviceAuthorization failed: %v", err)
+	}
+
+	token, err := session.WaitForToken()
+	if err != nil {
+		t.Fatalf("WaitForToken failed: %v", err)
+	}
+
+	if token.AccessToken != "access-123" {
+		t.Fatalf("expected access token %q, got %q", "access-123", token.AccessToken)
+	}
+	if token.RefreshToken != "refresh-456" {
+		t.Fatalf("expected refresh token %q, got %q", "refresh-456", token.RefreshToken)
+	}
+	if tokenRequests != 2 {
+		t.Fatalf("expected %d token requests, got %d", 2, tokenRequests)
+	}
+	if !slices.Equal(sleepCalls, []time.Duration{time.Second, time.Second}) {
+		t.Fatalf("expected sleep calls %v, got %v", []time.Duration{time.Second, time.Second}, sleepCalls)
+	}
+}
+
+func newOIDCTestConfig(t *testing.T, serverURL string) OIDCConfig {
+	t.Helper()
+
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+
+	return OIDCConfig{
+		AuthHostname: u.Host,
+		AuthRealm:    "cern",
+		ClientID:     "device-client",
+		VerifyCert:   false,
+	}
+}


### PR DESCRIPTION
Split the device authorization flow into a start phase that returns prompt metadata and a polling phase that waits for the token, so pkg/auth owns the protocol state while cmd/device owns stderr rendering.

Remove the OIDC quiet flag from auth-side flow configuration, keep the existing waiting-message behavior in the device command, and add focused tests for both the command-rendered instructions and the auth-side start/poll flow over a TLS test server.