### PR TITLE
feat(openshift): add device-exchange login flow

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -202,6 +202,31 @@ Verify that:
 2. The "Sign in with Kerberos" button is clicked automatically (if using Kerberos).
 3. The flow completes and cookies are saved.
 
+### Testing OpenShift Device-Exchange Manually
+
+The OpenShift device-exchange flow is covered by mocked automated tests. Live CERN verification is manual because the device authorization step is interactive.
+
+Run the flow:
+
+```bash
+go run . openshift --flow=device-exchange
+go run . openshift --flow=device-exchange --login-command
+go run . openshift --flow=device-exchange --json
+```
+
+Verify that:
+1. The device authorization instructions are printed to stderr.
+2. Completing the browser login returns a valid OpenShift token.
+3. Running the command a second time reuses the cached login-app and audience tokens without prompting again.
+4. `--login-command` prints an `oc login` command that points at the cluster API URL.
+5. `--json` keeps the same output shape as the existing OpenShift command.
+
+To force a fresh device login, clear the OpenShift cache directory:
+
+```bash
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/cern-sso-cli/openshift"
+```
+
 ## Building Without WebAuthn
 
 If you don't need WebAuthn support (to avoid the libfido2 dependency):

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -218,8 +218,9 @@ Verify that:
 1. The device authorization instructions are printed to stderr.
 2. Completing the browser login returns a valid OpenShift token.
 3. Running the command a second time reuses the cached login-app and audience tokens without prompting again.
-4. `--login-command` prints an `oc login` command that points at the cluster API URL.
-5. `--json` keeps the same output shape as the existing OpenShift command.
+4. If a cached audience token is rejected but the login-app cache is still usable, the command automatically re-exchanges and succeeds without manual cache clearing.
+5. `--login-command` prints an `oc login` command that points at the cluster API URL.
+6. `--json` keeps the same output shape as the existing OpenShift command.
 
 To force a fresh device login, clear the OpenShift cache directory:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Get your API token for OpenShift/OKD at CERN:
 cern-sso-cli openshift
 ```
 
+Use the device-exchange flow for headless environments or when you want an API-driven login path:
+
+```bash
+cern-sso-cli openshift --flow=device-exchange
+```
+
 Or get the full `oc login` command:
 ```bash
 cern-sso-cli openshift --login-command

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Use the device-exchange flow for headless environments or when you want an API-d
 cern-sso-cli openshift --flow=device-exchange
 ```
 
+The device-exchange flow caches login-app and audience tokens in `${XDG_CACHE_HOME:-$HOME/.cache}/cern-sso-cli/openshift`.
+It uses the OIDC device flow and does not support Kerberos/browser-specific auth flags such as `--auth-host`, `--user`, `--use-keytab`, or `--browser`.
+
 Or get the full `oc login` command:
 ```bash
 cern-sso-cli openshift --login-command

--- a/cmd/openshift.go
+++ b/cmd/openshift.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,6 +16,27 @@ const (
 	openShiftFlowWeb            = "web"
 	openShiftFlowDeviceExchange = "device-exchange"
 )
+
+var openShiftDeviceExchangeUnsupportedFlags = []string{
+	"auth-host",
+	"user",
+	"krb5-config",
+	"otp",
+	"otp-command",
+	"otp-keychain",
+	"otp-retries",
+	"webauthn-pin",
+	"webauthn-device",
+	"webauthn-device-index",
+	"webauthn-timeout",
+	"browser",
+	"use-otp",
+	"use-webauthn",
+	"keytab",
+	"use-password",
+	"use-keytab",
+	"use-ccache",
+}
 
 var (
 	openshiftURL      string
@@ -55,17 +77,12 @@ func init() {
 	openshiftCmd.Flags().BoolVarP(&openshiftInsecure, "insecure", "k", false, "Skip certificate validation")
 	openshiftCmd.Flags().BoolVar(&openshiftJSON, "json", false, "Output result as JSON")
 	openshiftCmd.Flags().BoolVar(&openshiftLoginCmd, "login-command", false, "Output full oc login command instead of just the token")
-	openshiftCmd.Flags().StringVar(&openshiftFlow, "flow", openShiftFlowWeb, "OpenShift authentication flow to use: web or device-exchange")
+	openshiftCmd.Flags().StringVar(&openshiftFlow, "flow", openShiftFlowWeb, "OpenShift authentication flow to use: web or device-exchange (device-exchange uses the OIDC device flow and does not support Kerberos/browser-specific auth flags)")
 }
 
 //nolint:cyclop // OpenShift OAuth authentication requires multiple steps
 func runOpenShift(cmd *cobra.Command, args []string) error {
-	// Validate mutually exclusive flags
-	if err := validateAuthCLIOptions(); err != nil {
-		return err
-	}
-
-	if err := validateOpenShiftFlow(); err != nil {
+	if err := validateOpenShiftCommand(cmd); err != nil {
 		return err
 	}
 
@@ -76,18 +93,42 @@ func runOpenShift(cmd *cobra.Command, args []string) error {
 	return runOpenShiftWeb()
 }
 
-func validateOpenShiftFlow() error {
+func validateOpenShiftCommand(cmd *cobra.Command) error {
+	if err := validateOpenShiftFlow(cmd); err != nil {
+		return err
+	}
+
+	if openshiftFlow == openShiftFlowWeb {
+		return validateAuthCLIOptions()
+	}
+
+	return nil
+}
+
+func validateOpenShiftFlow(cmd *cobra.Command) error {
 	switch openshiftFlow {
 	case openShiftFlowWeb, openShiftFlowDeviceExchange:
 	default:
 		return fmt.Errorf("invalid --flow %q: must be one of %q or %q", openshiftFlow, openShiftFlowWeb, openShiftFlowDeviceExchange)
 	}
 
-	if openshiftFlow == openShiftFlowDeviceExchange && openshiftAuthHost != defaultAuthHostname {
-		return fmt.Errorf("--auth-host cannot be used with --flow=%s; auth_url is determined from cluster DNS", openShiftFlowDeviceExchange)
+	if openshiftFlow != openShiftFlowDeviceExchange {
+		return nil
 	}
 
-	return nil
+	var unsupported []string
+	for _, name := range openShiftDeviceExchangeUnsupportedFlags {
+		flag := cmd.Flag(name)
+		if flag != nil && flag.Changed {
+			unsupported = append(unsupported, "--"+name)
+		}
+	}
+
+	if len(unsupported) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("--flow=%s does not support these flags: %s", openShiftFlowDeviceExchange, strings.Join(unsupported, ", "))
 }
 
 //nolint:cyclop // OpenShift OAuth authentication requires multiple steps

--- a/cmd/openshift.go
+++ b/cmd/openshift.go
@@ -11,12 +11,18 @@ import (
 
 const defaultOpenShiftURL = "https://paas.cern.ch"
 
+const (
+	openShiftFlowWeb            = "web"
+	openShiftFlowDeviceExchange = "device-exchange"
+)
+
 var (
 	openshiftURL      string
 	openshiftAuthHost string
 	openshiftInsecure bool
 	openshiftJSON     bool
 	openshiftLoginCmd bool
+	openshiftFlow     string
 )
 
 // OpenShiftLoginOutput represents the JSON output for the openshift command.
@@ -49,6 +55,7 @@ func init() {
 	openshiftCmd.Flags().BoolVarP(&openshiftInsecure, "insecure", "k", false, "Skip certificate validation")
 	openshiftCmd.Flags().BoolVar(&openshiftJSON, "json", false, "Output result as JSON")
 	openshiftCmd.Flags().BoolVar(&openshiftLoginCmd, "login-command", false, "Output full oc login command instead of just the token")
+	openshiftCmd.Flags().StringVar(&openshiftFlow, "flow", openShiftFlowWeb, "OpenShift authentication flow to use: web or device-exchange")
 }
 
 //nolint:cyclop // OpenShift OAuth authentication requires multiple steps
@@ -58,6 +65,33 @@ func runOpenShift(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := validateOpenShiftFlow(); err != nil {
+		return err
+	}
+
+	if openshiftFlow == openShiftFlowDeviceExchange {
+		return runOpenShiftDeviceExchange()
+	}
+
+	return runOpenShiftWeb()
+}
+
+func validateOpenShiftFlow() error {
+	switch openshiftFlow {
+	case openShiftFlowWeb, openShiftFlowDeviceExchange:
+	default:
+		return fmt.Errorf("invalid --flow %q: must be one of %q or %q", openshiftFlow, openShiftFlowWeb, openShiftFlowDeviceExchange)
+	}
+
+	if openshiftFlow == openShiftFlowDeviceExchange && openshiftAuthHost != defaultAuthHostname {
+		return fmt.Errorf("--auth-host cannot be used with --flow=%s; auth_url is determined from cluster DNS", openShiftFlowDeviceExchange)
+	}
+
+	return nil
+}
+
+//nolint:cyclop // OpenShift OAuth authentication requires multiple steps
+func runOpenShiftWeb() error {
 	// Derive the OAuth server URL from the base URL
 	// e.g., https://paas.cern.ch -> https://oauth-openshift.paas.cern.ch
 	parsedURL, err := url.Parse(openshiftURL)
@@ -93,6 +127,22 @@ func runOpenShift(cmd *cobra.Command, args []string) error {
 		cookies,
 		!openshiftInsecure,
 		logInfo,
+	)
+	if err != nil {
+		return err
+	}
+
+	return renderOpenShiftOutput(loginResult.Command, loginResult.Token, loginResult.Server)
+}
+
+func runOpenShiftDeviceExchange() error {
+	logInfo("Authenticating to OpenShift at %s using device-exchange flow...\n", openshiftURL)
+
+	loginResult, err := openshiftsvc.FetchLoginCommandWithDeviceExchange(
+		openshiftURL,
+		!openshiftInsecure,
+		logInfo,
+		renderDeviceInstructions,
 	)
 	if err != nil {
 		return err

--- a/cmd/openshift_test.go
+++ b/cmd/openshift_test.go
@@ -1,35 +1,174 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestValidateOpenShiftFlowRejectsUnknownValue(t *testing.T) {
-	oldFlow := openshiftFlow
-	oldAuthHost := openshiftAuthHost
-	defer func() {
-		openshiftFlow = oldFlow
-		openshiftAuthHost = oldAuthHost
-	}()
+	"github.com/spf13/cobra"
+)
+
+func TestValidateOpenShiftCommandRejectsUnknownFlow(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
 
 	openshiftFlow = "unknown"
-	openshiftAuthHost = defaultAuthHostname
 
-	if err := validateOpenShiftFlow(); err == nil {
+	if err := validateOpenShiftCommand(newOpenShiftValidationTestCommand()); err == nil {
 		t.Fatal("expected error for invalid flow")
 	}
 }
 
-func TestValidateOpenShiftFlowRejectsCustomAuthHostForDeviceExchange(t *testing.T) {
-	oldFlow := openshiftFlow
-	oldAuthHost := openshiftAuthHost
-	defer func() {
-		openshiftFlow = oldFlow
-		openshiftAuthHost = oldAuthHost
-	}()
+func TestValidateOpenShiftCommandRejectsCustomAuthHostForDeviceExchange(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
+
+	cmd := newOpenShiftValidationTestCommand()
+	mustSetOpenShiftTestFlag(t, cmd, "auth-host", "custom-auth.example")
 
 	openshiftFlow = openShiftFlowDeviceExchange
-	openshiftAuthHost = "custom-auth.example"
 
-	if err := validateOpenShiftFlow(); err == nil {
-		t.Fatal("expected error for custom auth host with device-exchange flow")
+	err := validateOpenShiftCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error for auth-host with device-exchange flow")
+	}
+	want := "--flow=device-exchange does not support these flags: --auth-host"
+	if err.Error() != want {
+		t.Fatalf("expected error %q, got %q", want, err.Error())
+	}
+}
+
+func TestValidateOpenShiftCommandRejectsExplicitDefaultBrowserFlagForDeviceExchange(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
+
+	cmd := newOpenShiftValidationTestCommand()
+	mustSetOpenShiftTestFlag(t, cmd, "browser", "false")
+
+	openshiftFlow = openShiftFlowDeviceExchange
+
+	err := validateOpenShiftCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error for explicitly set browser flag with device-exchange flow")
+	}
+	want := "--flow=device-exchange does not support these flags: --browser"
+	if err.Error() != want {
+		t.Fatalf("expected error %q, got %q", want, err.Error())
+	}
+}
+
+func TestValidateOpenShiftCommandRejectsMultipleUnsupportedFlagsInStableOrder(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
+
+	cmd := newOpenShiftValidationTestCommand()
+	mustSetOpenShiftTestFlag(t, cmd, "auth-host", "custom-auth.example")
+	mustSetOpenShiftTestFlag(t, cmd, "otp", "123456")
+	mustSetOpenShiftTestFlag(t, cmd, "use-keytab", "true")
+
+	openshiftFlow = openShiftFlowDeviceExchange
+
+	err := validateOpenShiftCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error for unsupported device-exchange flags")
+	}
+	want := "--flow=device-exchange does not support these flags: --auth-host, --otp, --use-keytab"
+	if err.Error() != want {
+		t.Fatalf("expected error %q, got %q", want, err.Error())
+	}
+}
+
+func TestValidateOpenShiftCommandAllowsDeviceExchangeWithDefaults(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
+
+	openshiftFlow = openShiftFlowDeviceExchange
+
+	if err := validateOpenShiftCommand(newOpenShiftValidationTestCommand()); err != nil {
+		t.Fatalf("expected defaults to pass for device-exchange flow, got %v", err)
+	}
+}
+
+func TestValidateOpenShiftCommandSkipsGenericAuthValidationForDeviceExchange(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
+
+	openshiftFlow = openShiftFlowDeviceExchange
+	usePassword = true
+	useCCache = true
+
+	if err := validateOpenShiftCommand(newOpenShiftValidationTestCommand()); err != nil {
+		t.Fatalf("expected device-exchange validation to skip generic auth validation, got %v", err)
+	}
+}
+
+func TestValidateOpenShiftCommandKeepsAuthValidationForWebFlow(t *testing.T) {
+	restore := saveOpenShiftValidationGlobals()
+	defer restore()
+
+	openshiftFlow = openShiftFlowWeb
+	usePassword = true
+	useCCache = true
+
+	err := validateOpenShiftCommand(newOpenShiftValidationTestCommand())
+	if err == nil {
+		t.Fatal("expected web flow to keep generic auth validation")
+	}
+	if !strings.Contains(err.Error(), "--use-password, --use-keytab, and --use-ccache") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func newOpenShiftValidationTestCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "openshift"}
+
+	cmd.Flags().String("auth-host", defaultAuthHostname, "")
+	cmd.Flags().String("user", "", "")
+	cmd.Flags().String("krb5-config", "", "")
+	cmd.Flags().String("otp", "", "")
+	cmd.Flags().String("otp-command", "", "")
+	cmd.Flags().String("otp-keychain", "", "")
+	cmd.Flags().Int("otp-retries", 3, "")
+	cmd.Flags().String("webauthn-pin", "", "")
+	cmd.Flags().String("webauthn-device", "", "")
+	cmd.Flags().Int("webauthn-device-index", -1, "")
+	cmd.Flags().Int("webauthn-timeout", 30, "")
+	cmd.Flags().Bool("browser", false, "")
+	cmd.Flags().Bool("use-otp", false, "")
+	cmd.Flags().Bool("use-webauthn", false, "")
+	cmd.Flags().String("keytab", "", "")
+	cmd.Flags().Bool("use-password", false, "")
+	cmd.Flags().Bool("use-keytab", false, "")
+	cmd.Flags().Bool("use-ccache", false, "")
+
+	return cmd
+}
+
+func mustSetOpenShiftTestFlag(t *testing.T, cmd *cobra.Command, name string, value string) {
+	t.Helper()
+
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("failed to set flag %q: %v", name, err)
+	}
+}
+
+func saveOpenShiftValidationGlobals() func() {
+	oldFlow := openshiftFlow
+	oldAuthHost := openshiftAuthHost
+	oldUsePassword := usePassword
+	oldUseKeytab := useKeytab
+	oldUseCCache := useCCache
+	oldKeytabPath := keytabPath
+	oldUseOTP := useOTP
+	oldUseWebAuthn := useWebAuthn
+
+	return func() {
+		openshiftFlow = oldFlow
+		openshiftAuthHost = oldAuthHost
+		usePassword = oldUsePassword
+		useKeytab = oldUseKeytab
+		useCCache = oldUseCCache
+		keytabPath = oldKeytabPath
+		useOTP = oldUseOTP
+		useWebAuthn = oldUseWebAuthn
 	}
 }

--- a/cmd/openshift_test.go
+++ b/cmd/openshift_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import "testing"
+
+func TestValidateOpenShiftFlowRejectsUnknownValue(t *testing.T) {
+	oldFlow := openshiftFlow
+	oldAuthHost := openshiftAuthHost
+	defer func() {
+		openshiftFlow = oldFlow
+		openshiftAuthHost = oldAuthHost
+	}()
+
+	openshiftFlow = "unknown"
+	openshiftAuthHost = defaultAuthHostname
+
+	if err := validateOpenShiftFlow(); err == nil {
+		t.Fatal("expected error for invalid flow")
+	}
+}
+
+func TestValidateOpenShiftFlowRejectsCustomAuthHostForDeviceExchange(t *testing.T) {
+	oldFlow := openshiftFlow
+	oldAuthHost := openshiftAuthHost
+	defer func() {
+		openshiftFlow = oldFlow
+		openshiftAuthHost = oldAuthHost
+	}()
+
+	openshiftFlow = openShiftFlowDeviceExchange
+	openshiftAuthHost = "custom-auth.example"
+
+	if err := validateOpenShiftFlow(); err == nil {
+		t.Fatal("expected error for custom auth host with device-exchange flow")
+	}
+}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -282,6 +282,48 @@ func (s *DeviceAuthorizationSession) WaitForToken() (*TokenResponse, error) {
 	}
 }
 
+// TokenRefresh refreshes an OIDC token using its refresh token.
+func TokenRefresh(cfg OIDCConfig, refreshToken string) (*TokenResponse, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("refresh token is required")
+	}
+
+	tokenURL := fmt.Sprintf(
+		"https://%s/auth/realms/%s/protocol/openid-connect/token",
+		cfg.AuthHostname, cfg.AuthRealm,
+	)
+
+	client := httpclient.New(httpclient.Config{
+		Timeout:    oidcHTTPTimeout,
+		VerifyCert: cfg.VerifyCert,
+	})
+
+	resp, err := client.PostForm(tokenURL, url.Values{
+		"client_id":     {cfg.ClientID},
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	if !isSuccessStatus(resp.StatusCode) {
+		return nil, fmt.Errorf("token refresh failed with status: %d", resp.StatusCode)
+	}
+
+	var token TokenResponse
+	if err := parseJSONResponse(resp, &token); err != nil {
+		return nil, err
+	}
+
+	return &token, nil
+}
+
 // TokenExchange performs a token exchange.
 func TokenExchange(cfg OIDCConfig, subjectToken, audience string) (*TokenResponse, error) {
 	tokenURL := fmt.Sprintf(

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -219,6 +219,94 @@ func TestTokenRefresh(t *testing.T) {
 	}
 }
 
+func TestTokenRefreshRejectsEmptyRefreshToken(t *testing.T) {
+	token, err := TokenRefresh(newOIDCTestConfig(t, "https://auth.example"), "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "refresh token is required" {
+		t.Fatalf("expected error %q, got %q", "refresh token is required", err.Error())
+	}
+	if token != nil {
+		t.Fatalf("expected nil token response, got %#v", token)
+	}
+}
+
+func TestTokenExchange(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body:       `{"access_token":"access-123","refresh_token":"refresh-456","expires_in":3600,"token_type":"Bearer"}`,
+		},
+		{
+			name:       "non-200 response",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_target"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "malformed json",
+			statusCode: http.StatusOK,
+			body:       `not-json`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/auth/realms/cern/protocol/openid-connect/token" {
+					t.Fatalf("unexpected path %q", r.URL.Path)
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("failed to parse form: %v", err)
+				}
+				if r.Form.Get("client_id") != "device-client" {
+					t.Fatalf("expected client_id %q, got %q", "device-client", r.Form.Get("client_id"))
+				}
+				if r.Form.Get("audience") != "paas_id" {
+					t.Fatalf("expected audience %q, got %q", "paas_id", r.Form.Get("audience"))
+				}
+				if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:token-exchange" {
+					t.Fatalf("unexpected grant_type %q", r.Form.Get("grant_type"))
+				}
+				if r.Form.Get("requested_token_type") != "urn:ietf:params:oauth:token-type:refresh_token" {
+					t.Fatalf("unexpected requested_token_type %q", r.Form.Get("requested_token_type"))
+				}
+				if r.Form.Get("subject_token") != "subject-123" {
+					t.Fatalf("expected subject_token %q, got %q", "subject-123", r.Form.Get("subject_token"))
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			token, err := TokenExchange(newOIDCTestConfig(t, server.URL), "subject-123", "paas_id")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TokenExchange failed: %v", err)
+			}
+			if token.AccessToken != "access-123" {
+				t.Fatalf("expected access token %q, got %q", "access-123", token.AccessToken)
+			}
+			if token.RefreshToken != "refresh-456" {
+				t.Fatalf("expected refresh token %q, got %q", "refresh-456", token.RefreshToken)
+			}
+		})
+	}
+}
+
 func newOIDCTestConfig(t *testing.T, serverURL string) OIDCConfig {
 	t.Helper()
 

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -153,6 +153,72 @@ func TestDeviceAuthorizationSessionWaitForToken(t *testing.T) {
 	}
 }
 
+func TestTokenRefresh(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body:       `{"access_token":"access-123","refresh_token":"refresh-456","expires_in":3600,"token_type":"Bearer"}`,
+		},
+		{
+			name:       "non-200 response",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_grant"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "malformed json",
+			statusCode: http.StatusOK,
+			body:       `not-json`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/auth/realms/cern/protocol/openid-connect/token" {
+					t.Fatalf("unexpected path %q", r.URL.Path)
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("failed to parse form: %v", err)
+				}
+				if r.Form.Get("grant_type") != "refresh_token" {
+					t.Fatalf("expected grant_type refresh_token, got %q", r.Form.Get("grant_type"))
+				}
+				if r.Form.Get("refresh_token") != "refresh-123" {
+					t.Fatalf("expected refresh token %q, got %q", "refresh-123", r.Form.Get("refresh_token"))
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			token, err := TokenRefresh(newOIDCTestConfig(t, server.URL), "refresh-123")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TokenRefresh failed: %v", err)
+			}
+			if token.AccessToken != "access-123" {
+				t.Fatalf("expected access token %q, got %q", "access-123", token.AccessToken)
+			}
+			if token.RefreshToken != "refresh-456" {
+				t.Fatalf("expected refresh token %q, got %q", "refresh-456", token.RefreshToken)
+			}
+		})
+	}
+}
+
 func newOIDCTestConfig(t *testing.T, serverURL string) OIDCConfig {
 	t.Helper()
 

--- a/pkg/services/openshift/config.go
+++ b/pkg/services/openshift/config.go
@@ -1,0 +1,189 @@
+package openshift
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/clelange/cern-sso-cli/pkg/auth"
+)
+
+const openShiftConfigDomainSuffix = ".okd.cern.ch"
+
+var lookupTXT = net.LookupTXT
+
+// ClusterConfig describes the DNS-published configuration for an OpenShift cluster.
+type ClusterConfig struct {
+	Name               string
+	APIURL             string
+	TokenExchangeURL   string
+	AudienceID         string
+	LoginApplicationID string
+	AuthURL            string
+}
+
+// LookupClusterConfig fetches the OpenShift cluster configuration from DNS TXT records.
+func LookupClusterConfig(clusterName string) (*ClusterConfig, error) {
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		return nil, fmt.Errorf("cluster name is required")
+	}
+
+	records, err := lookupTXT("_config." + clusterName + openShiftConfigDomainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup cluster config for %q: %w", clusterName, err)
+	}
+
+	cfg := &ClusterConfig{Name: clusterName}
+	for _, record := range records {
+		applyClusterConfigRecord(cfg, record)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// Validate verifies that the required cluster settings are present and plausible.
+func (c *ClusterConfig) Validate() error {
+	required := map[string]string{
+		"api_url":              c.APIURL,
+		"token_exchange_url":   c.TokenExchangeURL,
+		"audience_id":          c.AudienceID,
+		"login_application_id": c.LoginApplicationID,
+		"auth_url":             c.AuthURL,
+	}
+
+	for field, value := range required {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("cluster config missing required field %q", field)
+		}
+	}
+
+	for field, value := range map[string]string{
+		"api_url":            c.APIURL,
+		"token_exchange_url": c.TokenExchangeURL,
+		"auth_url":           c.AuthURL,
+	} {
+		if err := validateHTTPSURL(field, value); err != nil {
+			return err
+		}
+	}
+
+	if _, err := oidcConfigFromAuthURL(c.AuthURL, c.LoginApplicationID, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ClusterNameFromURL extracts the OpenShift cluster name from a console, API, or OAuth URL.
+func ClusterNameFromURL(rawURL string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", fmt.Errorf("cluster URL is required")
+	}
+
+	host, err := parseClusterHost(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	host = normalizeClusterHost(host)
+	if host == "" || !strings.Contains(host, ".") {
+		return "", fmt.Errorf("invalid cluster host %q", rawURL)
+	}
+
+	clusterName, _, ok := strings.Cut(host, ".")
+	if !ok || clusterName == "" {
+		return "", fmt.Errorf("could not determine cluster name from %q", rawURL)
+	}
+
+	return clusterName, nil
+}
+
+func oidcConfigFromAuthURL(authURL string, clientID string, verifyCerts bool) (auth.OIDCConfig, error) {
+	u, err := url.Parse(authURL)
+	if err != nil {
+		return auth.OIDCConfig{}, fmt.Errorf("invalid auth_url: %w", err)
+	}
+
+	if u.Host == "" {
+		return auth.OIDCConfig{}, fmt.Errorf("invalid auth_url %q: missing host", authURL)
+	}
+
+	pathParts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(pathParts) < 3 || pathParts[0] != "auth" || pathParts[1] != "realms" || pathParts[2] == "" {
+		return auth.OIDCConfig{}, fmt.Errorf("invalid auth_url %q: expected /auth/realms/<realm>", authURL)
+	}
+
+	return auth.OIDCConfig{
+		AuthHostname: u.Host,
+		AuthRealm:    pathParts[2],
+		ClientID:     clientID,
+		VerifyCert:   verifyCerts,
+	}, nil
+}
+
+func validateHTTPSURL(field string, rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid %s %q: %w", field, rawURL, err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("invalid %s %q: must be an https URL", field, rawURL)
+	}
+	return nil
+}
+
+func applyClusterConfigRecord(cfg *ClusterConfig, record string) {
+	key, value, ok := strings.Cut(strings.TrimSpace(record), "=")
+	if !ok {
+		return
+	}
+
+	switch key {
+	case "api_url":
+		cfg.APIURL = strings.TrimRight(value, "/")
+	case "token_exchange_url":
+		cfg.TokenExchangeURL = strings.TrimRight(value, "/")
+	case "audience_id":
+		cfg.AudienceID = value
+	case "login_application_id":
+		cfg.LoginApplicationID = value
+	case "auth_url":
+		cfg.AuthURL = strings.TrimRight(value, "/")
+	}
+}
+
+func parseClusterHost(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid cluster URL: %w", err)
+	}
+
+	if parsed.Hostname() != "" || strings.Contains(rawURL, "://") {
+		return parsed.Hostname(), nil
+	}
+
+	parsed, err = url.Parse("https://" + rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid cluster URL: %w", err)
+	}
+
+	return parsed.Hostname(), nil
+}
+
+func normalizeClusterHost(host string) string {
+	switch {
+	case strings.HasPrefix(host, "api."):
+		return strings.TrimPrefix(host, "api.")
+	case strings.HasPrefix(host, "oauth-openshift."):
+		return strings.TrimPrefix(host, "oauth-openshift.")
+	default:
+		return host
+	}
+}

--- a/pkg/services/openshift/config.go
+++ b/pkg/services/openshift/config.go
@@ -49,26 +49,34 @@ func LookupClusterConfig(clusterName string) (*ClusterConfig, error) {
 
 // Validate verifies that the required cluster settings are present and plausible.
 func (c *ClusterConfig) Validate() error {
-	required := map[string]string{
-		"api_url":              c.APIURL,
-		"token_exchange_url":   c.TokenExchangeURL,
-		"audience_id":          c.AudienceID,
-		"login_application_id": c.LoginApplicationID,
-		"auth_url":             c.AuthURL,
+	requiredFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "api_url", value: c.APIURL},
+		{name: "token_exchange_url", value: c.TokenExchangeURL},
+		{name: "audience_id", value: c.AudienceID},
+		{name: "login_application_id", value: c.LoginApplicationID},
+		{name: "auth_url", value: c.AuthURL},
 	}
 
-	for field, value := range required {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("cluster config missing required field %q", field)
+	for _, field := range requiredFields {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("cluster config missing required field %q", field.name)
 		}
 	}
 
-	for field, value := range map[string]string{
-		"api_url":            c.APIURL,
-		"token_exchange_url": c.TokenExchangeURL,
-		"auth_url":           c.AuthURL,
-	} {
-		if err := validateHTTPSURL(field, value); err != nil {
+	urlFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "api_url", value: c.APIURL},
+		{name: "token_exchange_url", value: c.TokenExchangeURL},
+		{name: "auth_url", value: c.AuthURL},
+	}
+
+	for _, field := range urlFields {
+		if err := validateHTTPSURL(field.name, field.value); err != nil {
 			return err
 		}
 	}

--- a/pkg/services/openshift/config_test.go
+++ b/pkg/services/openshift/config_test.go
@@ -1,0 +1,125 @@
+package openshift
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLookupClusterConfig(t *testing.T) {
+	oldLookupTXT := lookupTXT
+	defer func() { lookupTXT = oldLookupTXT }()
+
+	tests := []struct {
+		name    string
+		records []string
+		err     bool
+	}{
+		{
+			name: "valid config with extra records",
+			records: []string{
+				"api_url=https://api.paas.okd.cern.ch",
+				"token_exchange_url=https://token-exchange.paas.cern.ch",
+				"audience_id=paas_id",
+				"login_application_id=okd4-sso-login-application",
+				"auth_url=https://auth.cern.ch/auth/realms/cern",
+				"ignored_key=ignored",
+			},
+		},
+		{
+			name: "missing required field",
+			records: []string{
+				"api_url=https://api.paas.okd.cern.ch",
+				"token_exchange_url=https://token-exchange.paas.cern.ch",
+				"login_application_id=okd4-sso-login-application",
+				"auth_url=https://auth.cern.ch/auth/realms/cern",
+			},
+			err: true,
+		},
+		{
+			name: "malformed auth url",
+			records: []string{
+				"api_url=https://api.paas.okd.cern.ch",
+				"token_exchange_url=https://token-exchange.paas.cern.ch",
+				"audience_id=paas_id",
+				"login_application_id=okd4-sso-login-application",
+				"auth_url=https://auth.cern.ch/not-a-realm",
+			},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookupTXT = func(name string) ([]string, error) {
+				if name != "_config.paas.okd.cern.ch" {
+					t.Fatalf("unexpected lookup name %q", name)
+				}
+				return tt.records, nil
+			}
+
+			cfg, err := LookupClusterConfig("paas")
+			if tt.err {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("LookupClusterConfig failed: %v", err)
+			}
+			if cfg.Name != "paas" {
+				t.Fatalf("expected cluster name %q, got %q", "paas", cfg.Name)
+			}
+			if cfg.APIURL != "https://api.paas.okd.cern.ch" {
+				t.Fatalf("expected API URL %q, got %q", "https://api.paas.okd.cern.ch", cfg.APIURL)
+			}
+		})
+	}
+}
+
+func TestLookupClusterConfigPropagatesLookupError(t *testing.T) {
+	oldLookupTXT := lookupTXT
+	defer func() { lookupTXT = oldLookupTXT }()
+
+	lookupTXT = func(string) ([]string, error) {
+		return nil, errors.New("lookup failed")
+	}
+
+	if _, err := LookupClusterConfig("paas"); err == nil {
+		t.Fatal("expected lookup error")
+	}
+}
+
+func TestClusterNameFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		wantErr bool
+	}{
+		{name: "console url", rawURL: "https://paas.cern.ch", want: "paas"},
+		{name: "api url", rawURL: "https://api.paas.okd.cern.ch:6443", want: "paas"},
+		{name: "oauth url", rawURL: "https://oauth-openshift.paas.cern.ch/oauth/token/request", want: "paas"},
+		{name: "host without scheme", rawURL: "paas.cern.ch", want: "paas"},
+		{name: "invalid host", rawURL: "localhost", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ClusterNameFromURL(tt.rawURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ClusterNameFromURL failed: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected cluster name %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/services/openshift/config_test.go
+++ b/pkg/services/openshift/config_test.go
@@ -12,7 +12,7 @@ func TestLookupClusterConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		records []string
-		err     bool
+		wantErr string
 	}{
 		{
 			name: "valid config with extra records",
@@ -33,7 +33,7 @@ func TestLookupClusterConfig(t *testing.T) {
 				"login_application_id=okd4-sso-login-application",
 				"auth_url=https://auth.cern.ch/auth/realms/cern",
 			},
-			err: true,
+			wantErr: `cluster config missing required field "audience_id"`,
 		},
 		{
 			name: "malformed auth url",
@@ -44,7 +44,7 @@ func TestLookupClusterConfig(t *testing.T) {
 				"login_application_id=okd4-sso-login-application",
 				"auth_url=https://auth.cern.ch/not-a-realm",
 			},
-			err: true,
+			wantErr: `invalid auth_url "https://auth.cern.ch/not-a-realm": expected /auth/realms/<realm>`,
 		},
 	}
 
@@ -58,9 +58,12 @@ func TestLookupClusterConfig(t *testing.T) {
 			}
 
 			cfg, err := LookupClusterConfig("paas")
-			if tt.err {
+			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("expected error %q, got %q", tt.wantErr, err.Error())
 				}
 				return
 			}

--- a/pkg/services/openshift/device_exchange.go
+++ b/pkg/services/openshift/device_exchange.go
@@ -2,7 +2,9 @@ package openshift
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -41,6 +43,19 @@ type openShiftTokenResponse struct {
 	Token string `json:"token"`
 }
 
+type openShiftAPITokenExchangeError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *openShiftAPITokenExchangeError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("OpenShift token exchange failed with status: %d", e.StatusCode)
+	}
+
+	return fmt.Sprintf("OpenShift token exchange failed with status %d: %s", e.StatusCode, e.Body)
+}
+
 // FetchLoginCommandWithDeviceExchange authenticates to OpenShift using the CERN OIDC device flow.
 //
 //nolint:cyclop // Device-exchange flow has cache, refresh, exchange, and minting branches.
@@ -69,84 +84,161 @@ func FetchLoginCommandWithDeviceExchange(
 		return nil, err
 	}
 
-	audienceRecord, audienceErr := loadTokenCache(audienceCachePath(clusterConfig.AudienceID))
-	if audienceErr != nil && logf != nil {
-		logf("Ignoring cached audience token: %v\n", audienceErr)
-	}
-	if audienceRecord != nil && audienceRecord.isValid(deviceExchangeTimeNow()) {
-		if logf != nil {
-			logf("Reusing cached audience token for %s...\n", clusterConfig.AudienceID)
-		}
-		return mintOpenShiftLoginResult(clusterConfig, audienceRecord.AccessToken, verifyCerts)
-	}
+	audienceCache := audienceCachePath(clusterConfig.AudienceID)
+	loginCache := loginApplicationCachePath(clusterConfig.LoginApplicationID)
 
-	loginRecord, loginErr := loadTokenCache(loginApplicationCachePath(clusterConfig.LoginApplicationID))
-	if loginErr != nil && logf != nil {
-		logf("Ignoring cached login-app token: %v\n", loginErr)
-	}
-
-	var loginToken *auth.TokenResponse
-	switch {
-	case loginRecord != nil && loginRecord.isValid(deviceExchangeTimeNow()):
-		if logf != nil {
-			logf("Reusing cached login token for %s...\n", clusterConfig.LoginApplicationID)
-		}
-		loginToken = loginRecord.toTokenResponse()
-	case loginRecord != nil && loginRecord.RefreshToken != "":
-		if logf != nil {
-			logf("Refreshing cached login token for %s...\n", clusterConfig.LoginApplicationID)
-		}
-		loginToken, err = tokenRefresh(loginOIDC, loginRecord.RefreshToken)
-		if err == nil {
-			if err = saveTokenCache(loginApplicationCachePath(clusterConfig.LoginApplicationID), loginToken); err != nil {
-				return nil, err
-			}
-			break
-		}
-		if logf != nil {
-			logf("Cached login token refresh failed: %v\n", err)
-		}
-		loginToken = nil
-	}
-
-	if loginToken == nil {
-		if logf != nil {
-			logf("Starting device authorization for %s...\n", clusterConfig.LoginApplicationID)
-		}
-
-		session, err := startDeviceAuthorization(loginOIDC)
-		if err != nil {
-			return nil, fmt.Errorf("device authorization failed: %w", err)
-		}
-		if promptf != nil {
-			promptf(session.Prompt)
-		}
-
-		loginToken, err = waitForDeviceToken(session)
-		if err != nil {
-			return nil, fmt.Errorf("device authorization failed: %w", err)
-		}
-		if err := saveTokenCache(loginApplicationCachePath(clusterConfig.LoginApplicationID), loginToken); err != nil {
+	result, err := tryCachedAudienceToken(clusterConfig, audienceCache, verifyCerts, logf)
+	if err != nil {
+		var exchangeErr *openShiftAPITokenExchangeError
+		if !errors.As(err, &exchangeErr) || (exchangeErr.StatusCode != http.StatusUnauthorized && exchangeErr.StatusCode != http.StatusForbidden) {
 			return nil, err
 		}
+
+		if logf != nil {
+			logf("Cached audience token for %s was rejected with status %d; retrying with a fresh audience token...\n", clusterConfig.AudienceID, exchangeErr.StatusCode)
+		}
+		if err := removeTokenCache(audienceCache); err != nil && logf != nil {
+			logf("Failed to remove stale audience token cache %q: %v\n", audienceCache, err)
+		}
+	} else if result != nil {
+		return result, nil
+	}
+
+	loginToken, err := loadOrAcquireLoginToken(loginOIDC, loginCache, clusterConfig.LoginApplicationID, logf, promptf)
+	if err != nil {
+		return nil, err
+	}
+
+	audienceToken, err := exchangeAndCacheAudienceToken(loginOIDC, loginToken, clusterConfig.AudienceID, audienceCache, logf)
+	if err != nil {
+		return nil, err
+	}
+
+	return mintOpenShiftLoginResult(clusterConfig, audienceToken.AccessToken, verifyCerts)
+}
+
+func tryCachedAudienceToken(clusterConfig *ClusterConfig, audienceCache string, verifyCerts bool, logf LogFunc) (*LoginCommandResult, error) {
+	audienceRecord := loadCachedToken(audienceCache, "audience token", logf)
+	if audienceRecord == nil || !audienceRecord.isValid(deviceExchangeTimeNow()) {
+		return nil, nil
 	}
 
 	if logf != nil {
-		logf("Exchanging token for audience %s...\n", clusterConfig.AudienceID)
+		logf("Reusing cached audience token for %s...\n", clusterConfig.AudienceID)
 	}
 
-	audienceToken, err := tokenExchange(loginOIDC, loginToken.AccessToken, clusterConfig.AudienceID)
+	return mintOpenShiftLoginResult(clusterConfig, audienceRecord.AccessToken, verifyCerts)
+}
+
+func loadOrAcquireLoginToken(
+	loginOIDC auth.OIDCConfig,
+	loginCache string,
+	loginApplicationID string,
+	logf LogFunc,
+	promptf func(auth.DeviceAuthorizationPrompt),
+) (*auth.TokenResponse, error) {
+	loginRecord := loadCachedToken(loginCache, "login-app token", logf)
+
+	if loginToken, ok, err := tryCachedLoginToken(loginOIDC, loginCache, loginApplicationID, loginRecord, logf); ok {
+		return loginToken, err
+	}
+
+	return startDeviceAuthorizationToken(loginOIDC, loginCache, loginApplicationID, logf, promptf)
+}
+
+func tryCachedLoginToken(
+	loginOIDC auth.OIDCConfig,
+	loginCache string,
+	loginApplicationID string,
+	loginRecord *cachedToken,
+	logf LogFunc,
+) (*auth.TokenResponse, bool, error) {
+	if loginRecord == nil {
+		return nil, false, nil
+	}
+	if loginRecord.isValid(deviceExchangeTimeNow()) {
+		if logf != nil {
+			logf("Reusing cached login token for %s...\n", loginApplicationID)
+		}
+		return loginRecord.toTokenResponse(), true, nil
+	}
+	if loginRecord.RefreshToken == "" {
+		return nil, false, nil
+	}
+
+	if logf != nil {
+		logf("Refreshing cached login token for %s...\n", loginApplicationID)
+	}
+	loginToken, err := tokenRefresh(loginOIDC, loginRecord.RefreshToken)
+	if err != nil {
+		if logf != nil {
+			logf("Cached login token refresh failed: %v\n", err)
+		}
+		return nil, false, nil
+	}
+	if err := saveTokenCache(loginCache, loginToken); err != nil {
+		return nil, true, err
+	}
+
+	return loginToken, true, nil
+}
+
+func startDeviceAuthorizationToken(
+	loginOIDC auth.OIDCConfig,
+	loginCache string,
+	loginApplicationID string,
+	logf LogFunc,
+	promptf func(auth.DeviceAuthorizationPrompt),
+) (*auth.TokenResponse, error) {
+	if logf != nil {
+		logf("Starting device authorization for %s...\n", loginApplicationID)
+	}
+	session, err := startDeviceAuthorization(loginOIDC)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization failed: %w", err)
+	}
+	if promptf != nil {
+		promptf(session.Prompt)
+	}
+
+	loginToken, err := waitForDeviceToken(session)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization failed: %w", err)
+	}
+	if err := saveTokenCache(loginCache, loginToken); err != nil {
+		return nil, err
+	}
+
+	return loginToken, nil
+}
+
+func exchangeAndCacheAudienceToken(
+	loginOIDC auth.OIDCConfig,
+	loginToken *auth.TokenResponse,
+	audienceID string,
+	audienceCache string,
+	logf LogFunc,
+) (*auth.TokenResponse, error) {
+	if loginToken == nil || loginToken.AccessToken == "" {
+		return nil, fmt.Errorf("login token is required to exchange OpenShift audience token")
+	}
+
+	if logf != nil {
+		logf("Exchanging token for audience %s...\n", audienceID)
+	}
+
+	audienceToken, err := tokenExchange(loginOIDC, loginToken.AccessToken, audienceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange token for OpenShift audience: %w", err)
 	}
 	if audienceToken.AccessToken == "" {
 		return nil, fmt.Errorf("token exchange response missing access token")
 	}
-	if err := saveTokenCache(audienceCachePath(clusterConfig.AudienceID), audienceToken); err != nil {
+	if err := saveTokenCache(audienceCache, audienceToken); err != nil {
 		return nil, err
 	}
 
-	return mintOpenShiftLoginResult(clusterConfig, audienceToken.AccessToken, verifyCerts)
+	return audienceToken, nil
 }
 
 func mintOpenShiftLoginResult(clusterConfig *ClusterConfig, accessToken string, verifyCerts bool) (*LoginCommandResult, error) {
@@ -198,7 +290,12 @@ func exchangeOpenShiftAPIToken(tokenExchangeURL string, accessToken string, veri
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("OpenShift token exchange failed with status: %d", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		bodyText := strings.TrimSpace(string(body))
+		return "", &openShiftAPITokenExchangeError{
+			StatusCode: resp.StatusCode,
+			Body:       bodyText,
+		}
 	}
 
 	var response openShiftTokenResponse
@@ -251,6 +348,18 @@ func loadTokenCache(path string) (*cachedToken, error) {
 	return &record, nil
 }
 
+func loadCachedToken(path string, description string, logf LogFunc) *cachedToken {
+	record, err := loadTokenCache(path)
+	if err != nil {
+		if logf != nil {
+			logf("Ignoring cached %s: %v\n", description, err)
+		}
+		return nil
+	}
+
+	return record
+}
+
 func saveTokenCache(path string, token *auth.TokenResponse) error {
 	if token == nil {
 		return fmt.Errorf("token is required")
@@ -275,6 +384,14 @@ func saveTokenCache(path string, token *auth.TokenResponse) error {
 
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write cache %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func removeTokenCache(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove cache %q: %w", path, err)
 	}
 
 	return nil

--- a/pkg/services/openshift/device_exchange.go
+++ b/pkg/services/openshift/device_exchange.go
@@ -1,0 +1,328 @@
+package openshift
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/clelange/cern-sso-cli/internal/httpclient"
+	"github.com/clelange/cern-sso-cli/pkg/auth"
+)
+
+const (
+	openShiftTokenRedirectURI = "http://localhost" // #nosec G101 -- fixed public redirect placeholder required by the token-exchange API
+	cacheDirName              = "cern-sso-cli/openshift"
+	accessTokenExpirySkew     = 30 * time.Second
+)
+
+var (
+	deviceExchangeTimeNow    = time.Now
+	deviceExchangeUserCache  = os.UserCacheDir
+	startDeviceAuthorization = auth.StartDeviceAuthorization
+	waitForDeviceToken       = func(session *auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		return session.WaitForToken()
+	}
+	tokenExchange = auth.TokenExchange
+	tokenRefresh  = auth.TokenRefresh
+)
+
+type cachedToken struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+type openShiftTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// FetchLoginCommandWithDeviceExchange authenticates to OpenShift using the CERN OIDC device flow.
+//
+//nolint:cyclop // Device-exchange flow has cache, refresh, exchange, and minting branches.
+func FetchLoginCommandWithDeviceExchange(
+	clusterURL string,
+	verifyCerts bool,
+	logf LogFunc,
+	promptf func(auth.DeviceAuthorizationPrompt),
+) (*LoginCommandResult, error) {
+	clusterName, err := ClusterNameFromURL(clusterURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if logf != nil {
+		logf("Looking up OpenShift cluster config for %s...\n", clusterName)
+	}
+
+	clusterConfig, err := LookupClusterConfig(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	loginOIDC, err := oidcConfigFromAuthURL(clusterConfig.AuthURL, clusterConfig.LoginApplicationID, verifyCerts)
+	if err != nil {
+		return nil, err
+	}
+
+	audienceRecord, audienceErr := loadTokenCache(audienceCachePath(clusterConfig.AudienceID))
+	if audienceErr != nil && logf != nil {
+		logf("Ignoring cached audience token: %v\n", audienceErr)
+	}
+	if audienceRecord != nil && audienceRecord.isValid(deviceExchangeTimeNow()) {
+		if logf != nil {
+			logf("Reusing cached audience token for %s...\n", clusterConfig.AudienceID)
+		}
+		return mintOpenShiftLoginResult(clusterConfig, audienceRecord.AccessToken, verifyCerts)
+	}
+
+	loginRecord, loginErr := loadTokenCache(loginApplicationCachePath(clusterConfig.LoginApplicationID))
+	if loginErr != nil && logf != nil {
+		logf("Ignoring cached login-app token: %v\n", loginErr)
+	}
+
+	var loginToken *auth.TokenResponse
+	switch {
+	case loginRecord != nil && loginRecord.isValid(deviceExchangeTimeNow()):
+		if logf != nil {
+			logf("Reusing cached login token for %s...\n", clusterConfig.LoginApplicationID)
+		}
+		loginToken = loginRecord.toTokenResponse()
+	case loginRecord != nil && loginRecord.RefreshToken != "":
+		if logf != nil {
+			logf("Refreshing cached login token for %s...\n", clusterConfig.LoginApplicationID)
+		}
+		loginToken, err = tokenRefresh(loginOIDC, loginRecord.RefreshToken)
+		if err == nil {
+			if err = saveTokenCache(loginApplicationCachePath(clusterConfig.LoginApplicationID), loginToken); err != nil {
+				return nil, err
+			}
+			break
+		}
+		if logf != nil {
+			logf("Cached login token refresh failed: %v\n", err)
+		}
+		loginToken = nil
+	}
+
+	if loginToken == nil {
+		if logf != nil {
+			logf("Starting device authorization for %s...\n", clusterConfig.LoginApplicationID)
+		}
+
+		session, err := startDeviceAuthorization(loginOIDC)
+		if err != nil {
+			return nil, fmt.Errorf("device authorization failed: %w", err)
+		}
+		if promptf != nil {
+			promptf(session.Prompt)
+		}
+
+		loginToken, err = waitForDeviceToken(session)
+		if err != nil {
+			return nil, fmt.Errorf("device authorization failed: %w", err)
+		}
+		if err := saveTokenCache(loginApplicationCachePath(clusterConfig.LoginApplicationID), loginToken); err != nil {
+			return nil, err
+		}
+	}
+
+	if logf != nil {
+		logf("Exchanging token for audience %s...\n", clusterConfig.AudienceID)
+	}
+
+	audienceToken, err := tokenExchange(loginOIDC, loginToken.AccessToken, clusterConfig.AudienceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange token for OpenShift audience: %w", err)
+	}
+	if audienceToken.AccessToken == "" {
+		return nil, fmt.Errorf("token exchange response missing access token")
+	}
+	if err := saveTokenCache(audienceCachePath(clusterConfig.AudienceID), audienceToken); err != nil {
+		return nil, err
+	}
+
+	return mintOpenShiftLoginResult(clusterConfig, audienceToken.AccessToken, verifyCerts)
+}
+
+func mintOpenShiftLoginResult(clusterConfig *ClusterConfig, accessToken string, verifyCerts bool) (*LoginCommandResult, error) {
+	if accessToken == "" {
+		return nil, fmt.Errorf("audience access token is empty")
+	}
+
+	token, err := exchangeOpenShiftAPIToken(clusterConfig.TokenExchangeURL, accessToken, verifyCerts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LoginCommandResult{
+		Command: fmt.Sprintf("oc login --token=%s --server=%s", token, clusterConfig.APIURL),
+		Token:   token,
+		Server:  clusterConfig.APIURL,
+	}, nil
+}
+
+func exchangeOpenShiftAPIToken(tokenExchangeURL string, accessToken string, verifyCerts bool) (string, error) {
+	client := httpclient.New(httpclient.Config{
+		Timeout:    httpTimeout,
+		VerifyCert: verifyCerts,
+	})
+
+	endpoint, err := url.Parse(tokenExchangeURL + "/openshift-api-token")
+	if err != nil {
+		return "", fmt.Errorf("invalid token exchange URL: %w", err)
+	}
+
+	query := endpoint.Query()
+	query.Set("redirect-uri", openShiftTokenRedirectURI)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create OpenShift token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := client.Do(req) // #nosec G704
+	if err != nil {
+		return "", fmt.Errorf("failed to exchange OpenShift API token: %w", err)
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OpenShift token exchange failed with status: %d", resp.StatusCode)
+	}
+
+	var response openShiftTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return "", fmt.Errorf("failed to parse OpenShift token exchange response: %w", err)
+	}
+	if response.Token == "" {
+		return "", fmt.Errorf("OpenShift token exchange response missing token")
+	}
+
+	return response.Token, nil
+}
+
+func loginApplicationCachePath(clientID string) string {
+	return filepath.Join(cacheDirectory(), "login-"+sanitizeCacheKey(clientID)+".json")
+}
+
+func audienceCachePath(audienceID string) string {
+	return filepath.Join(cacheDirectory(), "audience-"+sanitizeCacheKey(audienceID)+".json")
+}
+
+func cacheDirectory() string {
+	cacheRoot, err := deviceExchangeUserCache()
+	if err != nil || cacheRoot == "" {
+		homeDir, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return filepath.Join(os.TempDir(), "cern-sso-cli", "openshift")
+		}
+		cacheRoot = filepath.Join(homeDir, ".cache")
+	}
+
+	return filepath.Join(cacheRoot, cacheDirName)
+}
+
+func loadTokenCache(path string) (*cachedToken, error) {
+	// #nosec G304 -- path is constructed by internal cache helpers under the user cache directory
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read cache %q: %w", path, err)
+	}
+
+	var record cachedToken
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, fmt.Errorf("failed to decode cache %q: %w", path, err)
+	}
+
+	return &record, nil
+}
+
+func saveTokenCache(path string, token *auth.TokenResponse) error {
+	if token == nil {
+		return fmt.Errorf("token is required")
+	}
+
+	record := cachedToken{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+	}
+	if token.ExpiresIn > 0 {
+		record.ExpiresAt = deviceExchangeTimeNow().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("failed to create cache dir: %w", err)
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("failed to encode cache: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write cache %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func (c *cachedToken) isValid(now time.Time) bool {
+	if c == nil || c.AccessToken == "" || c.ExpiresAt.IsZero() {
+		return false
+	}
+
+	return now.Add(accessTokenExpirySkew).Before(c.ExpiresAt)
+}
+
+func (c *cachedToken) toTokenResponse() *auth.TokenResponse {
+	if c == nil {
+		return nil
+	}
+
+	return &auth.TokenResponse{
+		AccessToken:  c.AccessToken,
+		RefreshToken: c.RefreshToken,
+	}
+}
+
+func sanitizeCacheKey(value string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		if isCacheKeyRuneAllowed(r) {
+			return r
+		}
+		return '_'
+	}, value)
+
+	if sanitized == "" {
+		return "token"
+	}
+
+	return sanitized
+}
+
+func isCacheKeyRuneAllowed(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	default:
+		return r == '.' || r == '-' || r == '_'
+	}
+}

--- a/pkg/services/openshift/device_exchange_test.go
+++ b/pkg/services/openshift/device_exchange_test.go
@@ -1,0 +1,321 @@
+package openshift
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/clelange/cern-sso-cli/pkg/auth"
+)
+
+func TestFetchLoginCommandWithDeviceExchangeUsesCachedAudienceToken(t *testing.T) {
+	oldLookupTXT := lookupTXT
+	oldNow := deviceExchangeTimeNow
+	oldUserCache := deviceExchangeUserCache
+	oldStart := startDeviceAuthorization
+	oldWait := waitForDeviceToken
+	oldExchange := tokenExchange
+	oldRefresh := tokenRefresh
+	defer func() {
+		lookupTXT = oldLookupTXT
+		deviceExchangeTimeNow = oldNow
+		deviceExchangeUserCache = oldUserCache
+		startDeviceAuthorization = oldStart
+		waitForDeviceToken = oldWait
+		tokenExchange = oldExchange
+		tokenRefresh = oldRefresh
+	}()
+
+	cacheDir := t.TempDir()
+	deviceExchangeUserCache = func() (string, error) { return cacheDir, nil }
+
+	now := time.Unix(1_700_000_000, 0)
+	deviceExchangeTimeNow = func() time.Time { return now }
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer audience-access" {
+			t.Fatalf("expected Authorization header %q, got %q", "Bearer audience-access", got)
+		}
+		if got := r.URL.Query().Get("redirect-uri"); got != openShiftTokenRedirectURI {
+			t.Fatalf("expected redirect-uri %q, got %q", openShiftTokenRedirectURI, got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "sha256~api-token"})
+	}))
+	defer server.Close()
+
+	lookupTXT = staticLookupTXT(server.URL)
+	startDeviceAuthorization = func(auth.OIDCConfig) (*auth.DeviceAuthorizationSession, error) {
+		t.Fatal("device authorization should not start when audience token is cached")
+		return nil, nil
+	}
+	waitForDeviceToken = func(*auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		t.Fatal("WaitForToken should not be called when audience token is cached")
+		return nil, nil
+	}
+	tokenExchange = func(auth.OIDCConfig, string, string) (*auth.TokenResponse, error) {
+		t.Fatal("token exchange should not be called when audience token is cached")
+		return nil, nil
+	}
+	tokenRefresh = func(auth.OIDCConfig, string) (*auth.TokenResponse, error) {
+		t.Fatal("token refresh should not be called when audience token is cached")
+		return nil, nil
+	}
+
+	if err := saveTokenCache(audienceCachePath("paas_id"), &auth.TokenResponse{
+		AccessToken: "audience-access",
+		ExpiresIn:   3600,
+	}); err != nil {
+		t.Fatalf("failed to seed audience cache: %v", err)
+	}
+
+	result, err := FetchLoginCommandWithDeviceExchange("https://paas.cern.ch", false, nil, nil)
+	if err != nil {
+		t.Fatalf("FetchLoginCommandWithDeviceExchange failed: %v", err)
+	}
+
+	if result.Token != "sha256~api-token" {
+		t.Fatalf("expected OpenShift token %q, got %q", "sha256~api-token", result.Token)
+	}
+	if result.Server != "https://api.paas.okd.cern.ch" {
+		t.Fatalf("expected server %q, got %q", "https://api.paas.okd.cern.ch", result.Server)
+	}
+}
+
+func TestFetchLoginCommandWithDeviceExchangeRefreshesLoginTokenAndCachesResults(t *testing.T) {
+	oldLookupTXT := lookupTXT
+	oldNow := deviceExchangeTimeNow
+	oldUserCache := deviceExchangeUserCache
+	oldStart := startDeviceAuthorization
+	oldWait := waitForDeviceToken
+	oldExchange := tokenExchange
+	oldRefresh := tokenRefresh
+	defer func() {
+		lookupTXT = oldLookupTXT
+		deviceExchangeTimeNow = oldNow
+		deviceExchangeUserCache = oldUserCache
+		startDeviceAuthorization = oldStart
+		waitForDeviceToken = oldWait
+		tokenExchange = oldExchange
+		tokenRefresh = oldRefresh
+	}()
+
+	cacheDir := t.TempDir()
+	deviceExchangeUserCache = func() (string, error) { return cacheDir, nil }
+
+	now := time.Unix(1_700_000_000, 0)
+	deviceExchangeTimeNow = func() time.Time { return now }
+
+	if err := saveTokenCache(loginApplicationCachePath("okd4-sso-login-application"), &auth.TokenResponse{
+		AccessToken:  "expired-login",
+		RefreshToken: "refresh-me",
+		ExpiresIn:    60,
+	}); err != nil {
+		t.Fatalf("failed to seed login cache: %v", err)
+	}
+
+	now = now.Add(2 * time.Hour)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer exchanged-access" {
+			t.Fatalf("expected Authorization header %q, got %q", "Bearer exchanged-access", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "sha256~api-token"})
+	}))
+	defer server.Close()
+
+	lookupTXT = staticLookupTXT(server.URL)
+	startDeviceAuthorization = func(auth.OIDCConfig) (*auth.DeviceAuthorizationSession, error) {
+		t.Fatal("device authorization should not start when refresh succeeds")
+		return nil, nil
+	}
+	waitForDeviceToken = func(*auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		t.Fatal("WaitForToken should not be called when refresh succeeds")
+		return nil, nil
+	}
+	tokenRefresh = func(cfg auth.OIDCConfig, refreshToken string) (*auth.TokenResponse, error) {
+		if cfg.ClientID != "okd4-sso-login-application" {
+			t.Fatalf("unexpected client id %q", cfg.ClientID)
+		}
+		if refreshToken != "refresh-me" {
+			t.Fatalf("unexpected refresh token %q", refreshToken)
+		}
+		return &auth.TokenResponse{
+			AccessToken:  "refreshed-login",
+			RefreshToken: "refresh-new",
+			ExpiresIn:    3600,
+		}, nil
+	}
+	tokenExchange = func(cfg auth.OIDCConfig, subjectToken string, audience string) (*auth.TokenResponse, error) {
+		if subjectToken != "refreshed-login" {
+			t.Fatalf("unexpected subject token %q", subjectToken)
+		}
+		if audience != "paas_id" {
+			t.Fatalf("unexpected audience %q", audience)
+		}
+		return &auth.TokenResponse{
+			AccessToken:  "exchanged-access",
+			RefreshToken: "audience-refresh",
+			ExpiresIn:    1800,
+		}, nil
+	}
+
+	result, err := FetchLoginCommandWithDeviceExchange("https://api.paas.okd.cern.ch", false, nil, nil)
+	if err != nil {
+		t.Fatalf("FetchLoginCommandWithDeviceExchange failed: %v", err)
+	}
+
+	if result.Token != "sha256~api-token" {
+		t.Fatalf("expected OpenShift token %q, got %q", "sha256~api-token", result.Token)
+	}
+
+	loginRecord, err := loadTokenCache(loginApplicationCachePath("okd4-sso-login-application"))
+	if err != nil {
+		t.Fatalf("failed to load login cache: %v", err)
+	}
+	if loginRecord.AccessToken != "refreshed-login" {
+		t.Fatalf("expected refreshed login token %q, got %q", "refreshed-login", loginRecord.AccessToken)
+	}
+
+	audienceRecord, err := loadTokenCache(audienceCachePath("paas_id"))
+	if err != nil {
+		t.Fatalf("failed to load audience cache: %v", err)
+	}
+	if audienceRecord.AccessToken != "exchanged-access" {
+		t.Fatalf("expected exchanged audience token %q, got %q", "exchanged-access", audienceRecord.AccessToken)
+	}
+}
+
+func TestFetchLoginCommandWithDeviceExchangeFallsBackToDeviceAuthorizationWhenRefreshFails(t *testing.T) {
+	oldLookupTXT := lookupTXT
+	oldNow := deviceExchangeTimeNow
+	oldUserCache := deviceExchangeUserCache
+	oldStart := startDeviceAuthorization
+	oldWait := waitForDeviceToken
+	oldExchange := tokenExchange
+	oldRefresh := tokenRefresh
+	defer func() {
+		lookupTXT = oldLookupTXT
+		deviceExchangeTimeNow = oldNow
+		deviceExchangeUserCache = oldUserCache
+		startDeviceAuthorization = oldStart
+		waitForDeviceToken = oldWait
+		tokenExchange = oldExchange
+		tokenRefresh = oldRefresh
+	}()
+
+	cacheDir := t.TempDir()
+	deviceExchangeUserCache = func() (string, error) { return cacheDir, nil }
+
+	now := time.Unix(1_700_000_000, 0)
+	deviceExchangeTimeNow = func() time.Time { return now }
+
+	if err := saveTokenCache(loginApplicationCachePath("okd4-sso-login-application"), &auth.TokenResponse{
+		AccessToken:  "expired-login",
+		RefreshToken: "refresh-me",
+		ExpiresIn:    60,
+	}); err != nil {
+		t.Fatalf("failed to seed login cache: %v", err)
+	}
+
+	now = now.Add(2 * time.Hour)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer exchanged-access" {
+			t.Fatalf("expected Authorization header %q, got %q", "Bearer exchanged-access", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "sha256~api-token"})
+	}))
+	defer server.Close()
+
+	lookupTXT = staticLookupTXT(server.URL)
+
+	promptCalls := 0
+	tokenRefresh = func(auth.OIDCConfig, string) (*auth.TokenResponse, error) {
+		return nil, errors.New("refresh failed")
+	}
+	startDeviceAuthorization = func(cfg auth.OIDCConfig) (*auth.DeviceAuthorizationSession, error) {
+		if cfg.ClientID != "okd4-sso-login-application" {
+			t.Fatalf("unexpected client id %q", cfg.ClientID)
+		}
+		return &auth.DeviceAuthorizationSession{
+			Prompt: auth.DeviceAuthorizationPrompt{
+				UserCode: "ABCD-EFGH",
+			},
+		}, nil
+	}
+	waitForDeviceToken = func(*auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		return &auth.TokenResponse{
+			AccessToken:  "device-login",
+			RefreshToken: "device-refresh",
+			ExpiresIn:    3600,
+		}, nil
+	}
+	tokenExchange = func(auth.OIDCConfig, string, string) (*auth.TokenResponse, error) {
+		return &auth.TokenResponse{
+			AccessToken: "exchanged-access",
+			ExpiresIn:   1800,
+		}, nil
+	}
+
+	_, err := FetchLoginCommandWithDeviceExchange("https://oauth-openshift.paas.cern.ch/oauth/token/request", false, nil, func(prompt auth.DeviceAuthorizationPrompt) {
+		promptCalls++
+		if prompt.UserCode != "ABCD-EFGH" {
+			t.Fatalf("unexpected prompt user code %q", prompt.UserCode)
+		}
+	})
+	if err != nil {
+		t.Fatalf("FetchLoginCommandWithDeviceExchange failed: %v", err)
+	}
+
+	if promptCalls != 1 {
+		t.Fatalf("expected prompt callback to be invoked once, got %d", promptCalls)
+	}
+
+	loginRecord, err := loadTokenCache(loginApplicationCachePath("okd4-sso-login-application"))
+	if err != nil {
+		t.Fatalf("failed to load login cache: %v", err)
+	}
+	if loginRecord.AccessToken != "device-login" {
+		t.Fatalf("expected device login token %q, got %q", "device-login", loginRecord.AccessToken)
+	}
+}
+
+func TestExchangeOpenShiftAPITokenErrorsOnBadResponse(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	if _, err := exchangeOpenShiftAPIToken(server.URL, "access-token", false); err == nil {
+		t.Fatal("expected token exchange error for bad status")
+	}
+}
+
+func TestExchangeOpenShiftAPITokenErrorsOnMissingToken(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"unexpected": "value"})
+	}))
+	defer server.Close()
+
+	if _, err := exchangeOpenShiftAPIToken(server.URL, "access-token", false); err == nil {
+		t.Fatal("expected token exchange error for missing token")
+	}
+}
+
+func staticLookupTXT(tokenExchangeURL string) func(string) ([]string, error) {
+	return func(name string) ([]string, error) {
+		if name != "_config.paas.okd.cern.ch" {
+			return nil, errors.New("unexpected lookup name")
+		}
+		return []string{
+			"api_url=https://api.paas.okd.cern.ch",
+			"token_exchange_url=" + tokenExchangeURL,
+			"audience_id=paas_id",
+			"login_application_id=okd4-sso-login-application",
+			"auth_url=https://auth.cern.ch/auth/realms/cern",
+		}, nil
+	}
+}

--- a/pkg/services/openshift/device_exchange_test.go
+++ b/pkg/services/openshift/device_exchange_test.go
@@ -5,13 +5,21 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/clelange/cern-sso-cli/pkg/auth"
 )
 
-func TestFetchLoginCommandWithDeviceExchangeUsesCachedAudienceToken(t *testing.T) {
+type deviceExchangeTestOverrides struct {
+	cacheDir string
+	now      func() time.Time
+}
+
+func setupDeviceExchangeTest(t *testing.T, opts deviceExchangeTestOverrides) {
+	t.Helper()
+
 	oldLookupTXT := lookupTXT
 	oldNow := deviceExchangeTimeNow
 	oldUserCache := deviceExchangeUserCache
@@ -19,7 +27,8 @@ func TestFetchLoginCommandWithDeviceExchangeUsesCachedAudienceToken(t *testing.T
 	oldWait := waitForDeviceToken
 	oldExchange := tokenExchange
 	oldRefresh := tokenRefresh
-	defer func() {
+
+	t.Cleanup(func() {
 		lookupTXT = oldLookupTXT
 		deviceExchangeTimeNow = oldNow
 		deviceExchangeUserCache = oldUserCache
@@ -27,13 +36,23 @@ func TestFetchLoginCommandWithDeviceExchangeUsesCachedAudienceToken(t *testing.T
 		waitForDeviceToken = oldWait
 		tokenExchange = oldExchange
 		tokenRefresh = oldRefresh
-	}()
+	})
 
-	cacheDir := t.TempDir()
-	deviceExchangeUserCache = func() (string, error) { return cacheDir, nil }
+	if opts.cacheDir == "" {
+		opts.cacheDir = t.TempDir()
+	}
+	deviceExchangeUserCache = func() (string, error) { return opts.cacheDir, nil }
 
+	if opts.now != nil {
+		deviceExchangeTimeNow = opts.now
+	}
+}
+
+func TestFetchLoginCommandWithDeviceExchangeUsesCachedAudienceToken(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	deviceExchangeTimeNow = func() time.Time { return now }
+	setupDeviceExchangeTest(t, deviceExchangeTestOverrides{
+		now: func() time.Time { return now },
+	})
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer audience-access" {
@@ -84,29 +103,219 @@ func TestFetchLoginCommandWithDeviceExchangeUsesCachedAudienceToken(t *testing.T
 	}
 }
 
-func TestFetchLoginCommandWithDeviceExchangeRefreshesLoginTokenAndCachesResults(t *testing.T) {
-	oldLookupTXT := lookupTXT
-	oldNow := deviceExchangeTimeNow
-	oldUserCache := deviceExchangeUserCache
-	oldStart := startDeviceAuthorization
-	oldWait := waitForDeviceToken
-	oldExchange := tokenExchange
-	oldRefresh := tokenRefresh
-	defer func() {
-		lookupTXT = oldLookupTXT
-		deviceExchangeTimeNow = oldNow
-		deviceExchangeUserCache = oldUserCache
-		startDeviceAuthorization = oldStart
-		waitForDeviceToken = oldWait
-		tokenExchange = oldExchange
-		tokenRefresh = oldRefresh
-	}()
-
-	cacheDir := t.TempDir()
-	deviceExchangeUserCache = func() (string, error) { return cacheDir, nil }
-
+func TestFetchLoginCommandWithDeviceExchangeRecoversFromRejectedCachedAudienceToken(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	deviceExchangeTimeNow = func() time.Time { return now }
+	setupDeviceExchangeTest(t, deviceExchangeTestOverrides{
+		now: func() time.Time { return now },
+	})
+
+	if err := saveTokenCache(audienceCachePath("paas_id"), &auth.TokenResponse{
+		AccessToken: "stale-audience",
+		ExpiresIn:   4 * 3600,
+	}); err != nil {
+		t.Fatalf("failed to seed audience cache: %v", err)
+	}
+	if err := saveTokenCache(loginApplicationCachePath("okd4-sso-login-application"), &auth.TokenResponse{
+		AccessToken: "cached-login",
+		ExpiresIn:   3600,
+	}); err != nil {
+		t.Fatalf("failed to seed login cache: %v", err)
+	}
+
+	mintCalls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mintCalls++
+		switch mintCalls {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-audience" {
+				t.Fatalf("expected Authorization header %q, got %q", "Bearer stale-audience", got)
+			}
+			http.Error(w, "stale token", http.StatusUnauthorized)
+		case 2:
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh-audience" {
+				t.Fatalf("expected Authorization header %q, got %q", "Bearer fresh-audience", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "sha256~api-token"})
+		default:
+			t.Fatalf("unexpected mint attempt %d", mintCalls)
+		}
+	}))
+	defer server.Close()
+
+	lookupTXT = staticLookupTXT(server.URL)
+	startDeviceAuthorization = func(auth.OIDCConfig) (*auth.DeviceAuthorizationSession, error) {
+		t.Fatal("device authorization should not start during audience-token recovery")
+		return nil, nil
+	}
+	waitForDeviceToken = func(*auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		t.Fatal("WaitForToken should not be called during audience-token recovery")
+		return nil, nil
+	}
+
+	refreshCalls := 0
+	tokenRefresh = func(auth.OIDCConfig, string) (*auth.TokenResponse, error) {
+		refreshCalls++
+		t.Fatal("token refresh should not be called when login token cache is still valid")
+		return nil, nil
+	}
+
+	exchangeCalls := 0
+	tokenExchange = func(cfg auth.OIDCConfig, subjectToken string, audience string) (*auth.TokenResponse, error) {
+		exchangeCalls++
+		if subjectToken != "cached-login" {
+			t.Fatalf("unexpected subject token %q", subjectToken)
+		}
+		if audience != "paas_id" {
+			t.Fatalf("unexpected audience %q", audience)
+		}
+		return &auth.TokenResponse{
+			AccessToken: "fresh-audience",
+			ExpiresIn:   1800,
+		}, nil
+	}
+
+	result, err := FetchLoginCommandWithDeviceExchange("https://paas.cern.ch", false, nil, nil)
+	if err != nil {
+		t.Fatalf("FetchLoginCommandWithDeviceExchange failed: %v", err)
+	}
+
+	if result.Token != "sha256~api-token" {
+		t.Fatalf("expected OpenShift token %q, got %q", "sha256~api-token", result.Token)
+	}
+	if exchangeCalls != 1 {
+		t.Fatalf("expected %d token exchange call, got %d", 1, exchangeCalls)
+	}
+	if refreshCalls != 0 {
+		t.Fatalf("expected %d refresh calls, got %d", 0, refreshCalls)
+	}
+	if mintCalls != 2 {
+		t.Fatalf("expected %d mint attempts, got %d", 2, mintCalls)
+	}
+
+	audienceRecord, err := loadTokenCache(audienceCachePath("paas_id"))
+	if err != nil {
+		t.Fatalf("failed to load audience cache: %v", err)
+	}
+	if audienceRecord.AccessToken != "fresh-audience" {
+		t.Fatalf("expected refreshed audience token %q, got %q", "fresh-audience", audienceRecord.AccessToken)
+	}
+}
+
+func TestFetchLoginCommandWithDeviceExchangeRefreshesLoginTokenAfterRejectedCachedAudienceToken(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	setupDeviceExchangeTest(t, deviceExchangeTestOverrides{
+		now: func() time.Time { return now },
+	})
+
+	if err := saveTokenCache(audienceCachePath("paas_id"), &auth.TokenResponse{
+		AccessToken: "stale-audience",
+		ExpiresIn:   4 * 3600,
+	}); err != nil {
+		t.Fatalf("failed to seed audience cache: %v", err)
+	}
+	if err := saveTokenCache(loginApplicationCachePath("okd4-sso-login-application"), &auth.TokenResponse{
+		AccessToken:  "expired-login",
+		RefreshToken: "refresh-me",
+		ExpiresIn:    60,
+	}); err != nil {
+		t.Fatalf("failed to seed login cache: %v", err)
+	}
+
+	now = now.Add(2 * time.Hour)
+
+	mintCalls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mintCalls++
+		switch mintCalls {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-audience" {
+				t.Fatalf("expected Authorization header %q, got %q", "Bearer stale-audience", got)
+			}
+			http.Error(w, "forbidden", http.StatusForbidden)
+		case 2:
+			if got := r.Header.Get("Authorization"); got != "Bearer refreshed-audience" {
+				t.Fatalf("expected Authorization header %q, got %q", "Bearer refreshed-audience", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "sha256~api-token"})
+		default:
+			t.Fatalf("unexpected mint attempt %d", mintCalls)
+		}
+	}))
+	defer server.Close()
+
+	lookupTXT = staticLookupTXT(server.URL)
+	startDeviceAuthorization = func(auth.OIDCConfig) (*auth.DeviceAuthorizationSession, error) {
+		t.Fatal("device authorization should not start when login token refresh succeeds")
+		return nil, nil
+	}
+	waitForDeviceToken = func(*auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		t.Fatal("WaitForToken should not be called when login token refresh succeeds")
+		return nil, nil
+	}
+
+	refreshCalls := 0
+	tokenRefresh = func(cfg auth.OIDCConfig, refreshToken string) (*auth.TokenResponse, error) {
+		refreshCalls++
+		if cfg.ClientID != "okd4-sso-login-application" {
+			t.Fatalf("unexpected client id %q", cfg.ClientID)
+		}
+		if refreshToken != "refresh-me" {
+			t.Fatalf("unexpected refresh token %q", refreshToken)
+		}
+		return &auth.TokenResponse{
+			AccessToken:  "refreshed-login",
+			RefreshToken: "refresh-new",
+			ExpiresIn:    3600,
+		}, nil
+	}
+
+	exchangeCalls := 0
+	tokenExchange = func(cfg auth.OIDCConfig, subjectToken string, audience string) (*auth.TokenResponse, error) {
+		exchangeCalls++
+		if subjectToken != "refreshed-login" {
+			t.Fatalf("unexpected subject token %q", subjectToken)
+		}
+		if audience != "paas_id" {
+			t.Fatalf("unexpected audience %q", audience)
+		}
+		return &auth.TokenResponse{
+			AccessToken: "refreshed-audience",
+			ExpiresIn:   1800,
+		}, nil
+	}
+
+	result, err := FetchLoginCommandWithDeviceExchange("https://paas.cern.ch", false, nil, nil)
+	if err != nil {
+		t.Fatalf("FetchLoginCommandWithDeviceExchange failed: %v", err)
+	}
+
+	if result.Token != "sha256~api-token" {
+		t.Fatalf("expected OpenShift token %q, got %q", "sha256~api-token", result.Token)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("expected %d refresh call, got %d", 1, refreshCalls)
+	}
+	if exchangeCalls != 1 {
+		t.Fatalf("expected %d token exchange call, got %d", 1, exchangeCalls)
+	}
+	if mintCalls != 2 {
+		t.Fatalf("expected %d mint attempts, got %d", 2, mintCalls)
+	}
+
+	loginRecord, err := loadTokenCache(loginApplicationCachePath("okd4-sso-login-application"))
+	if err != nil {
+		t.Fatalf("failed to load login cache: %v", err)
+	}
+	if loginRecord.AccessToken != "refreshed-login" {
+		t.Fatalf("expected refreshed login token %q, got %q", "refreshed-login", loginRecord.AccessToken)
+	}
+}
+
+func TestFetchLoginCommandWithDeviceExchangeRefreshesLoginTokenAndCachesResults(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	setupDeviceExchangeTest(t, deviceExchangeTestOverrides{
+		now: func() time.Time { return now },
+	})
 
 	if err := saveTokenCache(loginApplicationCachePath("okd4-sso-login-application"), &auth.TokenResponse{
 		AccessToken:  "expired-login",
@@ -189,28 +398,10 @@ func TestFetchLoginCommandWithDeviceExchangeRefreshesLoginTokenAndCachesResults(
 }
 
 func TestFetchLoginCommandWithDeviceExchangeFallsBackToDeviceAuthorizationWhenRefreshFails(t *testing.T) {
-	oldLookupTXT := lookupTXT
-	oldNow := deviceExchangeTimeNow
-	oldUserCache := deviceExchangeUserCache
-	oldStart := startDeviceAuthorization
-	oldWait := waitForDeviceToken
-	oldExchange := tokenExchange
-	oldRefresh := tokenRefresh
-	defer func() {
-		lookupTXT = oldLookupTXT
-		deviceExchangeTimeNow = oldNow
-		deviceExchangeUserCache = oldUserCache
-		startDeviceAuthorization = oldStart
-		waitForDeviceToken = oldWait
-		tokenExchange = oldExchange
-		tokenRefresh = oldRefresh
-	}()
-
-	cacheDir := t.TempDir()
-	deviceExchangeUserCache = func() (string, error) { return cacheDir, nil }
-
 	now := time.Unix(1_700_000_000, 0)
-	deviceExchangeTimeNow = func() time.Time { return now }
+	setupDeviceExchangeTest(t, deviceExchangeTestOverrides{
+		now: func() time.Time { return now },
+	})
 
 	if err := saveTokenCache(loginApplicationCachePath("okd4-sso-login-application"), &auth.TokenResponse{
 		AccessToken:  "expired-login",
@@ -283,14 +474,87 @@ func TestFetchLoginCommandWithDeviceExchangeFallsBackToDeviceAuthorizationWhenRe
 	}
 }
 
+func TestFetchLoginCommandWithDeviceExchangeDoesNotRetryNonAuthAudienceMintFailures(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	setupDeviceExchangeTest(t, deviceExchangeTestOverrides{
+		now: func() time.Time { return now },
+	})
+
+	if err := saveTokenCache(audienceCachePath("paas_id"), &auth.TokenResponse{
+		AccessToken: "stale-audience",
+		ExpiresIn:   3600,
+	}); err != nil {
+		t.Fatalf("failed to seed audience cache: %v", err)
+	}
+
+	mintCalls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mintCalls++
+		http.Error(w, "upstream failed", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	lookupTXT = staticLookupTXT(server.URL)
+	startDeviceAuthorization = func(auth.OIDCConfig) (*auth.DeviceAuthorizationSession, error) {
+		t.Fatal("device authorization should not start for non-auth mint failures")
+		return nil, nil
+	}
+	waitForDeviceToken = func(*auth.DeviceAuthorizationSession) (*auth.TokenResponse, error) {
+		t.Fatal("WaitForToken should not be called for non-auth mint failures")
+		return nil, nil
+	}
+	tokenExchange = func(auth.OIDCConfig, string, string) (*auth.TokenResponse, error) {
+		t.Fatal("token exchange should not run for non-auth mint failures")
+		return nil, nil
+	}
+	tokenRefresh = func(auth.OIDCConfig, string) (*auth.TokenResponse, error) {
+		t.Fatal("token refresh should not run for non-auth mint failures")
+		return nil, nil
+	}
+
+	_, err := FetchLoginCommandWithDeviceExchange("https://paas.cern.ch", false, nil, nil)
+	if err == nil {
+		t.Fatal("expected mint failure")
+	}
+	if mintCalls != 1 {
+		t.Fatalf("expected %d mint attempt, got %d", 1, mintCalls)
+	}
+
+	var exchangeErr *openShiftAPITokenExchangeError
+	if !errors.As(err, &exchangeErr) {
+		t.Fatalf("expected OpenShift token exchange error, got %T", err)
+	}
+	if exchangeErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected status %d, got %d", http.StatusBadGateway, exchangeErr.StatusCode)
+	}
+	if exchangeErr.Body != "upstream failed" {
+		t.Fatalf("expected response body %q, got %q", "upstream failed", exchangeErr.Body)
+	}
+}
+
 func TestExchangeOpenShiftAPITokenErrorsOnBadResponse(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad request", http.StatusBadGateway)
 	}))
 	defer server.Close()
 
-	if _, err := exchangeOpenShiftAPIToken(server.URL, "access-token", false); err == nil {
+	_, err := exchangeOpenShiftAPIToken(server.URL, "access-token", false)
+	if err == nil {
 		t.Fatal("expected token exchange error for bad status")
+	}
+
+	var exchangeErr *openShiftAPITokenExchangeError
+	if !errors.As(err, &exchangeErr) {
+		t.Fatalf("expected OpenShift token exchange error, got %T", err)
+	}
+	if exchangeErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected status %d, got %d", http.StatusBadGateway, exchangeErr.StatusCode)
+	}
+	if exchangeErr.Body != "bad request" {
+		t.Fatalf("expected response body %q, got %q", "bad request", exchangeErr.Body)
+	}
+	if !strings.Contains(err.Error(), "bad request") {
+		t.Fatalf("expected error to include response body, got %q", err.Error())
 	}
 }
 

--- a/pkg/services/openshift/device_exchange_test.go
+++ b/pkg/services/openshift/device_exchange_test.go
@@ -305,6 +305,43 @@ func TestExchangeOpenShiftAPITokenErrorsOnMissingToken(t *testing.T) {
 	}
 }
 
+func TestSanitizeCacheKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "preserves safe characters",
+			input: "Login-App_01.prod",
+			want:  "Login-App_01.prod",
+		},
+		{
+			name:  "replaces unsafe characters",
+			input: "audience/id with spaces",
+			want:  "audience_id_with_spaces",
+		},
+		{
+			name:  "maps punctuation to underscores",
+			input: "!!!",
+			want:  "___",
+		},
+		{
+			name:  "falls back for empty input",
+			input: "",
+			want:  "token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeCacheKey(tt.input); got != tt.want {
+				t.Fatalf("expected sanitized cache key %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func staticLookupTXT(tokenExchangeURL string) func(string) ([]string, error) {
 	return func(name string) ([]string, error) {
 		if name != "_config.paas.okd.cern.ch" {


### PR DESCRIPTION
Add an opt-in OpenShift device-exchange backend behind --flow=device-exchange while keeping the existing web flow as the default.

Implement cluster config lookup from DNS TXT records, login-app and audience token caching, login-app token refresh, and the OpenShift token-exchange client.

Cover the new behavior with command, OIDC, config, and device-exchange tests, and document both usage and manual verification steps.

Fixes #127 