### PR TITLE
fix(auth): support Keycloak 26.5 WebAuthn options

### DIFF
--- a/pkg/auth/kerberos_login_steps.go
+++ b/pkg/auth/kerberos_login_steps.go
@@ -510,6 +510,7 @@ func (f *kerberosLoginFlow) handleWebAuthn(resp *http.Response, authBody []byte)
 	if err != nil {
 		return nil, &LoginError{Message: fmt.Sprintf("failed to parse WebAuthn form: %v", err)}
 	}
+	webauthnForm.Origin = responseOrigin(resp)
 
 	result, err := f.client.webauthnProvider.Authenticate(webauthnForm)
 	if err != nil {
@@ -535,6 +536,18 @@ func (f *kerberosLoginFlow) handleWebAuthn(resp *http.Response, authBody []byte)
 	}
 
 	return nextResp, nil
+}
+
+func responseOrigin(resp *http.Response) string {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil ||
+		resp.Request.URL.Scheme == "" || resp.Request.URL.Host == "" {
+		return ""
+	}
+
+	return (&url.URL{
+		Scheme: resp.Request.URL.Scheme,
+		Host:   resp.Request.URL.Host,
+	}).String()
 }
 
 func (f *kerberosLoginFlow) handleOTP(authBody []byte) (*http.Response, error) {

--- a/pkg/auth/kerberos_login_steps_test.go
+++ b/pkg/auth/kerberos_login_steps_test.go
@@ -62,6 +62,22 @@ func TestFetchKerberosLoginPageFollowsInitialGitLabOIDC(t *testing.T) {
 	}
 }
 
+func TestResponseOrigin(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://auth.cern.ch:8443/auth/realms/cern/login-actions/authenticate", nil)
+	resp := &http.Response{Request: req}
+
+	if got := responseOrigin(resp); got != "https://auth.cern.ch:8443" {
+		t.Fatalf("responseOrigin() = %q, expected %q", got, "https://auth.cern.ch:8443")
+	}
+	if got := responseOrigin(nil); got != "" {
+		t.Fatalf("responseOrigin(nil) = %q, expected empty origin", got)
+	}
+	relativeResp := &http.Response{Request: &http.Request{URL: &url.URL{Path: "/authenticate"}}}
+	if got := responseOrigin(relativeResp); got != "" {
+		t.Fatalf("responseOrigin(relative URL) = %q, expected empty origin", got)
+	}
+}
+
 func TestFetchKerberosLoginPageFollowsInitialSAMLRequest(t *testing.T) {
 	kc := newLoginStepsTestClient(t)
 	defer kc.Close()

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -265,12 +265,18 @@ func ParseOTPForm(r io.Reader) (*OTPForm, error) {
 // WebAuthnForm represents the structure of a Keycloak WebAuthn form.
 type WebAuthnForm struct {
 	Action        string            // Form action URL
+	Origin        string            // Origin of the page requesting the assertion
 	Challenge     string            // Base64URL-encoded challenge
 	RPID          string            // Relying Party ID
 	CredentialIDs []string          // Allowed credential IDs (base64url encoded)
 	UserHandle    string            // User handle (base64url encoded)
 	HiddenFields  map[string]string // Other hidden input fields
 }
+
+var (
+	webAuthnChallengePattern = regexp.MustCompile(`\bchallenge\s*:\s*['"]([^'"]+)['"]`)
+	webAuthnRPIDPattern      = regexp.MustCompile(`\brpId\s*:\s*['"]([^'"]+)['"]`)
+)
 
 // ParseWebAuthnForm extracts the WebAuthn form details from the CERN 2FA page.
 // Keycloak's WebAuthn page structure:
@@ -335,19 +341,17 @@ func ParseWebAuthnForm(r io.Reader) (*WebAuthnForm, error) {
 	doc.Find("script").Each(func(i int, s *goquery.Selection) {
 		scriptContent := s.Text()
 
-		// Look for challenge in the input object: challenge : 'xxx'
+		// Look for challenge in the input object. Keycloak 26.5 changed these
+		// JavaScript string literals from single quotes to double quotes.
 		if strings.Contains(scriptContent, "challenge") {
-			// Pattern: challenge : 'value' or challenge: 'value'
-			challengePattern := regexp.MustCompile(`challenge\s*:\s*'([^']+)'`)
-			if matches := challengePattern.FindStringSubmatch(scriptContent); len(matches) > 1 {
+			if matches := webAuthnChallengePattern.FindStringSubmatch(scriptContent); len(matches) > 1 {
 				webauthnForm.Challenge = matches[1]
 			}
 		}
 
-		// Look for rpId: rpId : 'xxx'
+		// Look for rpId: rpId : 'xxx' or rpId : "xxx"
 		if strings.Contains(scriptContent, "rpId") {
-			rpIdPattern := regexp.MustCompile(`rpId\s*:\s*'([^']+)'`)
-			if matches := rpIdPattern.FindStringSubmatch(scriptContent); len(matches) > 1 {
+			if matches := webAuthnRPIDPattern.FindStringSubmatch(scriptContent); len(matches) > 1 {
 				webauthnForm.RPID = matches[1]
 			}
 		}
@@ -365,6 +369,13 @@ func ParseWebAuthnForm(r io.Reader) (*WebAuthnForm, error) {
 			webauthnForm.RPID = rpid
 		}
 	})
+
+	if webauthnForm.Challenge == "" {
+		return nil, errors.New("WebAuthn challenge not found")
+	}
+	if webauthnForm.RPID == "" {
+		return nil, errors.New("WebAuthn RP ID not found")
+	}
 
 	return webauthnForm, nil
 }

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -304,6 +304,103 @@ func TestParseTryAnotherWayForm_NotFound(t *testing.T) {
 	}
 }
 
+func TestParseWebAuthnForm(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		challenge string
+	}{
+		{
+			name:      "Keycloak 26.4 single-quoted values",
+			challenge: "challenge-264",
+			script: `const input = {
+				challenge : 'challenge-264',
+				rpId : 'auth.cern.ch'
+			};`,
+		},
+		{
+			name:      "Keycloak 26.5 double-quoted values",
+			challenge: "challenge-265",
+			script: `const input = {
+				challenge : "challenge-265",
+				rpId : "auth.cern.ch"
+			};`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			html := `<html><body>
+				<div id="kc-form-webauthn">
+					<form id="webauth" action="/authenticate">
+						<input type="hidden" name="session_code" value="session-123">
+					</form>
+				</div>
+				<form id="authn_select">
+					<input name="authn_use_chk" value="credential-123">
+				</form>
+				<script>` + tt.script + `</script>
+			</body></html>`
+
+			form, err := ParseWebAuthnForm(strings.NewReader(html))
+			if err != nil {
+				t.Fatalf("ParseWebAuthnForm failed: %v", err)
+			}
+
+			if form.Action != "/authenticate" {
+				t.Errorf("Action = %q, expected %q", form.Action, "/authenticate")
+			}
+			if form.Challenge != tt.challenge {
+				t.Errorf("Challenge = %q, expected %q", form.Challenge, tt.challenge)
+			}
+			if form.RPID != "auth.cern.ch" {
+				t.Errorf("RPID = %q, expected %q", form.RPID, "auth.cern.ch")
+			}
+			if form.HiddenFields["session_code"] != "session-123" {
+				t.Errorf("session_code = %q, expected %q", form.HiddenFields["session_code"], "session-123")
+			}
+			if len(form.CredentialIDs) != 1 || form.CredentialIDs[0] != "credential-123" {
+				t.Errorf("CredentialIDs = %q, expected [credential-123]", form.CredentialIDs)
+			}
+		})
+	}
+}
+
+func TestParseWebAuthnFormRequiresAssertionParameters(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		errorText string
+	}{
+		{
+			name:      "missing challenge",
+			script:    `const input = { rpId : "auth.cern.ch" };`,
+			errorText: "challenge not found",
+		},
+		{
+			name:      "missing RP ID",
+			script:    `const input = { challenge : "challenge-123" };`,
+			errorText: "RP ID not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			html := `<div id="kc-form-webauthn">
+				<form id="webauth" action="/authenticate"></form>
+			</div><script>` + tt.script + `</script>`
+
+			_, err := ParseWebAuthnForm(strings.NewReader(html))
+			if err == nil {
+				t.Fatal("expected parsing error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errorText) {
+				t.Fatalf("error = %q, expected it to contain %q", err, tt.errorText)
+			}
+		})
+	}
+}
+
 func TestParseMethodSelectionPage(t *testing.T) {
 	// HTML structure based on TryAnotherWay.html
 	html := `

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -123,6 +123,12 @@ func (p *WebAuthnProvider) Authenticate(form *WebAuthnForm) (*WebAuthnResult, er
 	if form == nil {
 		return nil, errors.New("webauthn form is nil")
 	}
+	if form.Challenge == "" {
+		return nil, errors.New("webauthn challenge is empty")
+	}
+	if form.RPID == "" {
+		return nil, errors.New("webauthn RP ID is empty")
+	}
 
 	// Find available FIDO2 devices
 	locs, err := libfido2.DeviceLocations()
@@ -187,8 +193,12 @@ func (p *WebAuthnProvider) Authenticate(form *WebAuthnForm) (*WebAuthnResult, er
 	}
 	// Note: Device doesn't have a public Close method, cleanup is handled internally
 	// Build clientDataJSON (this is what the browser creates)
-	// The origin must use "https://" prefix for WebAuthn
-	origin := fmt.Sprintf("https://%s", form.RPID)
+	// The origin is the authentication page's origin. It may differ from the RP
+	// ID when credentials are scoped to a parent domain.
+	origin := form.Origin
+	if origin == "" {
+		origin = fmt.Sprintf("https://%s", form.RPID)
+	}
 	clientDataJSON := fmt.Sprintf(`{"type":"webauthn.get","challenge":"%s","origin":"%s","crossOrigin":false}`,
 		form.Challenge, origin)
 

--- a/pkg/auth/webauthn_test.go
+++ b/pkg/auth/webauthn_test.go
@@ -1,0 +1,44 @@
+//go:build !nowebauthn
+
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWebAuthnAuthenticateValidatesAssertionParameters(t *testing.T) {
+	tests := []struct {
+		name      string
+		form      *WebAuthnForm
+		errorText string
+	}{
+		{
+			name:      "nil form",
+			errorText: "form is nil",
+		},
+		{
+			name:      "empty challenge",
+			form:      &WebAuthnForm{RPID: "auth.cern.ch"},
+			errorText: "challenge is empty",
+		},
+		{
+			name:      "empty RP ID",
+			form:      &WebAuthnForm{Challenge: "challenge-123"},
+			errorText: "RP ID is empty",
+		},
+	}
+
+	provider := &WebAuthnProvider{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := provider.Authenticate(tt.form)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errorText) {
+				t.Fatalf("error = %q, expected it to contain %q", err, tt.errorText)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- parse WebAuthn `challenge` and `rpId` values emitted with either single or double quotes
- validate required WebAuthn assertion parameters before accessing a FIDO2 device
- build `clientDataJSON` with the authentication page origin instead of assuming the origin equals the RP ID
- add regression coverage for Keycloak 26.4 and 26.5+ templates

## Why

Keycloak 26.5 changed its WebAuthn template to emit JavaScript-safe, double-quoted string literals. The CLI parser only accepted single-quoted values, leaving both the challenge and RP ID empty. `go-libfido2` then failed with `no rpID specified` after the CLI displayed the security-key touch prompt.

## Impact

Native FIDO2/YubiKey authentication works with current Keycloak pages while remaining compatible with older templates. Parser drift now fails before device interaction with a specific missing-parameter error.

## Validation

- `make test`
- `go test -tags nowebauthn ./pkg/auth`
- `make lint`
- `pre-commit run --all-files`
- `make build build-no-webauthn check-certs`
