### PR TITLE
fix(auth): support CERN Users Portal

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -169,12 +169,12 @@ The integration tests verify:
 - Cookie generation and management
 - Multi-domain cookie handling
 - Authorization Code Flow (OIDC)
-- SPA fallback mechanisms (Harbor, OpenShift)
+- SPA fallback mechanisms (Users Portal, Harbor, OpenShift)
 - CLI secret extraction (Harbor)
 - Token retrieval (OpenShift)
 
 **Verified services:**
-- `account.web.cern.ch` (Standard SSO)
+- `users-portal.web.cern.ch` (Users Portal - SPA/OIDC)
 - `gitlab.cern.ch` (Standard SSO)
 - `paas.cern.ch` (OpenShift - SPA)
 - `registry.cern.ch` (Harbor - SPA/OIDC)

--- a/integration_test.go
+++ b/integration_test.go
@@ -24,12 +24,14 @@ import (
 
 const testVersion = "dev"
 
-func TestIntegration_AccountWebCERN(t *testing.T) {
+const usersPortalURL = "https://users-portal.web.cern.ch/identities/me/otherAccounts"
+
+func TestIntegration_UsersPortal(t *testing.T) {
 	skipIfNoCredentials(t)
 
-	targetURL := "https://account.web.cern.ch/Management/MyAccounts.aspx"
+	targetURL := usersPortalURL
 	authHost := "auth.cern.ch"
-	cookieFile := "test_account_cookies.txt"
+	cookieFile := "test_users_portal_cookies.txt"
 	defer os.Remove(cookieFile)
 
 	// Test cookie generation
@@ -63,7 +65,7 @@ func TestIntegration_AccountWebCERN(t *testing.T) {
 	}
 
 	// Verify cookies work with curl
-	verifyCookiesIntegration(t, cookieFile, targetURL, "Account Management")
+	verifyCookiesIntegration(t, cookieFile, targetURL, "CERN Users Portal")
 }
 
 func TestIntegration_MultiDomainCookies(t *testing.T) {
@@ -72,8 +74,8 @@ func TestIntegration_MultiDomainCookies(t *testing.T) {
 	cookieFile := "test_multi_domain_cookies.txt"
 	defer os.Remove(cookieFile)
 
-	// First, authenticate to account.web.cern.ch
-	accountURL := "https://account.web.cern.ch/Management/MyAccounts.aspx"
+	// First, authenticate to the CERN Users Portal
+	portalURL := usersPortalURL
 	authHost := "auth.cern.ch"
 
 	kerbClient, err := auth.NewKerberosClient(testVersion, "", true)
@@ -81,22 +83,22 @@ func TestIntegration_MultiDomainCookies(t *testing.T) {
 		t.Fatalf("Failed to create Kerberos client: %v", err)
 	}
 
-	result, err := kerbClient.LoginWithKerberos(accountURL, authHost, true)
+	result, err := kerbClient.LoginWithKerberos(portalURL, authHost, true)
 	if err != nil {
-		t.Fatalf("Account login failed: %v", err)
+		t.Fatalf("Users Portal login failed: %v", err)
 	}
 
-	accountCookies, err := kerbClient.CollectCookies(accountURL, authHost, result)
+	portalCookies, err := kerbClient.CollectCookies(portalURL, authHost, result)
 	if err != nil {
-		t.Fatalf("Failed to collect account cookies: %v", err)
+		t.Fatalf("Failed to collect Users Portal cookies: %v", err)
 	}
-	t.Logf("Collected %d cookies for account.web.cern.ch", len(accountCookies))
+	t.Logf("Collected %d cookies for users-portal.web.cern.ch", len(portalCookies))
 
-	// Save account cookies
-	u1, _ := url.Parse(accountURL)
+	// Save Users Portal cookies
+	u1, _ := url.Parse(portalURL)
 	jar, _ := cookie.NewJar()
-	if err := jar.Save(cookieFile, accountCookies, u1.Hostname()); err != nil {
-		t.Fatalf("Failed to save account cookies: %v", err)
+	if err := jar.Save(cookieFile, portalCookies, u1.Hostname()); err != nil {
+		t.Fatalf("Failed to save Users Portal cookies: %v", err)
 	}
 	kerbClient.Close()
 
@@ -120,7 +122,7 @@ func TestIntegration_MultiDomainCookies(t *testing.T) {
 	}
 	t.Logf("Collected %d cookies for gitlab.cern.ch", len(gitlabCookies))
 
-	// Update with gitlab cookies (should preserve account cookies)
+	// Update with GitLab cookies (should preserve Users Portal cookies)
 	u2, _ := url.Parse(gitlabURL)
 	if err := jar.Update(cookieFile, gitlabCookies, u2.Hostname()); err != nil {
 		t.Fatalf("Failed to update with GitLab cookies: %v", err)
@@ -132,23 +134,24 @@ func TestIntegration_MultiDomainCookies(t *testing.T) {
 		t.Fatalf("Failed to load cookies: %v", err)
 	}
 
-	accountDomainFound := false
+	usersPortalDomainFound := false
 	gitlabDomainFound := false
 	for _, c := range allCookies {
-		if strings.Contains(c.Domain, "account") || strings.Contains(c.Domain, "cern.ch") {
-			if strings.Contains(c.Domain, "account") {
-				accountDomainFound = true
-			}
+		if strings.Contains(c.Domain, "users-portal") {
+			usersPortalDomainFound = true
 		}
 		if strings.Contains(c.Domain, "gitlab") {
 			gitlabDomainFound = true
 		}
 	}
 
-	if !accountDomainFound || !gitlabDomainFound {
+	if !usersPortalDomainFound || !gitlabDomainFound {
 		t.Logf("Cookies found: %d", len(allCookies))
 		for _, c := range allCookies {
 			t.Logf("  %s: domain=%s", c.Name, c.Domain)
+		}
+		if !usersPortalDomainFound {
+			t.Errorf("Users Portal cookies not found in file")
 		}
 		if !gitlabDomainFound {
 			t.Errorf("GitLab cookies not found in file")
@@ -164,8 +167,8 @@ func TestIntegration_CookieReuse(t *testing.T) {
 	cookieFile := "test_cookie_reuse.txt"
 	defer os.Remove(cookieFile)
 
-	// First, authenticate to account.web.cern.ch to get auth.cern.ch cookies
-	accountURL := "https://account.web.cern.ch/Management/MyAccounts.aspx"
+	// First, authenticate to the Users Portal to get auth.cern.ch cookies
+	portalURL := usersPortalURL
 	authHost := "auth.cern.ch"
 
 	kerbClient, err := auth.NewKerberosClient(testVersion, "", true)
@@ -173,22 +176,22 @@ func TestIntegration_CookieReuse(t *testing.T) {
 		t.Fatalf("Failed to create Kerberos client: %v", err)
 	}
 
-	result, err := kerbClient.LoginWithKerberos(accountURL, authHost, true)
+	result, err := kerbClient.LoginWithKerberos(portalURL, authHost, true)
 	if err != nil {
-		t.Fatalf("Account login failed: %v", err)
+		t.Fatalf("Users Portal login failed: %v", err)
 	}
 
-	accountCookies, err := kerbClient.CollectCookies(accountURL, authHost, result)
+	portalCookies, err := kerbClient.CollectCookies(portalURL, authHost, result)
 	if err != nil {
-		t.Fatalf("Failed to collect account cookies: %v", err)
+		t.Fatalf("Failed to collect Users Portal cookies: %v", err)
 	}
-	t.Logf("Collected %d cookies for account.web.cern.ch (includes auth.cern.ch cookies)", len(accountCookies))
+	t.Logf("Collected %d cookies for users-portal.web.cern.ch (includes auth.cern.ch cookies)", len(portalCookies))
 
-	// Save account cookies (this includes auth.cern.ch cookies)
-	u1, _ := url.Parse(accountURL)
+	// Save Users Portal cookies (this includes auth.cern.ch cookies)
+	u1, _ := url.Parse(portalURL)
 	jar, _ := cookie.NewJar()
-	if err := jar.Save(cookieFile, accountCookies, u1.Hostname()); err != nil {
-		t.Fatalf("Failed to save account cookies: %v", err)
+	if err := jar.Save(cookieFile, portalCookies, u1.Hostname()); err != nil {
+		t.Fatalf("Failed to save Users Portal cookies: %v", err)
 	}
 	kerbClient.Close()
 
@@ -292,12 +295,12 @@ func TestIntegration_GitLabCERN(t *testing.T) {
 func TestIntegration_AuthorizationCodeFlow(t *testing.T) {
 	skipIfNoCredentials(t)
 
-	// Use account-app as a test client
+	// Use the Users Portal as a test client
 	cfg := auth.OIDCConfig{
 		AuthHostname: "auth.cern.ch",
 		AuthRealm:    "cern",
-		ClientID:     "account-app",
-		RedirectURI:  "https://account.web.cern.ch/authorization-code/callback",
+		ClientID:     "users-portal",
+		RedirectURI:  usersPortalURL,
 		VerifyCert:   true,
 	}
 

--- a/pkg/auth/kerberos_login.go
+++ b/pkg/auth/kerberos_login.go
@@ -21,7 +21,7 @@ type LoginResult struct {
 // full Kerberos authentication for each new CERN subdomain.
 //
 // Example flow:
-//  1. User authenticates to account.web.cern.ch with Kerberos
+//  1. User authenticates to users-portal.web.cern.ch with Kerberos
 //  2. auth.cern.ch cookies are saved to cookies.txt
 //  3. Later, user wants to authenticate to gitlab.cern.ch
 //  4. TryLoginWithCookies reuses auth.cern.ch cookies

--- a/pkg/auth/spa_fallback.go
+++ b/pkg/auth/spa_fallback.go
@@ -13,14 +13,20 @@ import (
 
 // SPAType constants for known SPA applications
 const (
-	SPATypeUnknown   = ""
-	SPATypeHarbor    = "harbor"
-	SPATypeOpenShift = "openshift"
+	SPATypeUnknown     = ""
+	SPATypeHarbor      = "harbor"
+	SPATypeOpenShift   = "openshift"
+	SPATypeUsersPortal = "users-portal"
+
+	legacyAccountHostname  = "account.web.cern.ch"
+	usersPortalHostname    = "users-portal.web.cern.ch"
+	usersPortalClientID    = "users-portal"
+	usersPortalRedirectURI = "https://users-portal.web.cern.ch/identities/me/otherAccounts"
 )
 
 // SPAInfo contains detected SPA configuration
 type SPAInfo struct {
-	Type     string // SPATypeHarbor, SPATypeOpenShift, etc.
+	Type     string // One of the SPAType constants above
 	LoginURL string // Direct login URL that triggers OIDC flow
 	ClientID string // OIDC client ID (if extractable)
 	BaseURL  string // Base URL of the target site
@@ -37,6 +43,12 @@ type HarborSystemInfo struct {
 // Called when ParseKerberosLink fails on the landing page.
 // bodyBytes contains the HTML response from the initial request.
 func DetectSPA(client *http.Client, targetURL string, bodyBytes []byte) (*SPAInfo, error) {
+	// The Users Portal has no unauthenticated API to probe, so identify its
+	// static shell before trying network-based SPA detection.
+	if info, err := DetectUsersPortal(bodyBytes, targetURL); err == nil && info != nil {
+		return info, nil
+	}
+
 	// Try Harbor detection first
 	if info, err := DetectHarbor(client, targetURL); err == nil && info != nil {
 		return info, nil
@@ -48,6 +60,30 @@ func DetectSPA(client *http.Client, targetURL string, bodyBytes []byte) (*SPAInf
 	}
 
 	return nil, fmt.Errorf("no known SPA pattern detected")
+}
+
+// DetectUsersPortal checks for the CERN Users Portal static application shell.
+// The legacy Account Management URL redirects to this shell, so both hostnames
+// are accepted while the OIDC callback always uses the registered portal URL.
+func DetectUsersPortal(bodyBytes []byte, targetURL string) (*SPAInfo, error) {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	hostname := strings.ToLower(u.Hostname())
+	if hostname != usersPortalHostname && hostname != legacyAccountHostname {
+		return nil, fmt.Errorf("not the CERN Users Portal hostname")
+	}
+	if !strings.Contains(string(bodyBytes), "<title>CERN Users Portal</title>") {
+		return nil, fmt.Errorf("not the CERN Users Portal page")
+	}
+
+	return &SPAInfo{
+		Type:     SPATypeUsersPortal,
+		ClientID: usersPortalClientID,
+		BaseURL:  "https://" + usersPortalHostname,
+	}, nil
 }
 
 // DetectHarbor checks for Harbor registry indicators by probing the systeminfo API.
@@ -138,6 +174,8 @@ func GetSPALoginPage(client *http.Client, spaInfo *SPAInfo, authHostname string)
 		return getHarborLoginPage(client, spaInfo, authHostname)
 	case SPATypeOpenShift:
 		return getOpenShiftLoginPage(client, spaInfo)
+	case SPATypeUsersPortal:
+		return getUsersPortalLoginPage(client, spaInfo, authHostname)
 	default:
 		return "", nil, fmt.Errorf("unknown SPA type: %s", spaInfo.Type)
 	}
@@ -165,18 +203,36 @@ func getHarborLoginPage(client *http.Client, spaInfo *SPAInfo, authHostname stri
 	authURL := fmt.Sprintf("https://%s/auth/realms/cern/protocol/openid-connect/auth", authHostname)
 	redirectURI := fmt.Sprintf("%s://%s/c/oidc/callback", u.Scheme, u.Host)
 
+	fullURL := buildOIDCAuthorizationURL(authURL, clientID, redirectURI)
+	return fetchOIDCLoginPage(client, fullURL, "Harbor")
+}
+
+func getUsersPortalLoginPage(client *http.Client, spaInfo *SPAInfo, authHostname string) (string, []byte, error) {
+	clientID := spaInfo.ClientID
+	if clientID == "" {
+		clientID = usersPortalClientID
+	}
+
+	authURL := fmt.Sprintf("https://%s/auth/realms/cern/protocol/openid-connect/auth", authHostname)
+	fullURL := buildOIDCAuthorizationURL(authURL, clientID, usersPortalRedirectURI)
+	return fetchOIDCLoginPage(client, fullURL, "Users Portal")
+}
+
+func buildOIDCAuthorizationURL(authURL, clientID, redirectURI string) string {
 	params := url.Values{}
 	params.Set("client_id", clientID)
 	params.Set("redirect_uri", redirectURI)
 	params.Set("response_type", "code")
 	params.Set("scope", "openid")
 
-	fullURL := authURL + "?" + params.Encode()
+	return authURL + "?" + params.Encode()
+}
 
+func fetchOIDCLoginPage(client *http.Client, fullURL, service string) (string, []byte, error) {
 	// Fetch the login page
 	resp, err := client.Get(fullURL)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to fetch Harbor login page: %w", err)
+		return "", nil, fmt.Errorf("failed to fetch %s login page: %w", service, err)
 	}
 	defer func() {
 		if resp != nil && resp.Body != nil {
@@ -186,7 +242,7 @@ func getHarborLoginPage(client *http.Client, spaInfo *SPAInfo, authHostname stri
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to read Harbor login page: %w", err)
+		return "", nil, fmt.Errorf("failed to read %s login page: %w", service, err)
 	}
 
 	return resp.Request.URL.String(), body, nil

--- a/pkg/auth/spa_fallback_test.go
+++ b/pkg/auth/spa_fallback_test.go
@@ -3,8 +3,64 @@ package auth
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
+
+func TestDetectUsersPortal(t *testing.T) {
+	portalHTML := []byte(`<!doctype html><html><head><title>CERN Users Portal</title></head></html>`)
+
+	tests := []struct {
+		name      string
+		targetURL string
+		body      []byte
+		wantErr   bool
+	}{
+		{
+			name:      "current Users Portal",
+			targetURL: usersPortalRedirectURI,
+			body:      portalHTML,
+		},
+		{
+			name:      "legacy Account Management redirect",
+			targetURL: "https://account.web.cern.ch/Management/MyAccounts.aspx",
+			body:      portalHTML,
+		},
+		{
+			name:      "wrong hostname",
+			targetURL: "https://example.com/",
+			body:      portalHTML,
+			wantErr:   true,
+		},
+		{
+			name:      "wrong page",
+			targetURL: usersPortalRedirectURI,
+			body:      []byte(`<html><head><title>Other application</title></head></html>`),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := DetectUsersPortal(tt.body, tt.targetURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("DetectUsersPortal() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DetectUsersPortal() unexpected error: %v", err)
+			}
+			if info.Type != SPATypeUsersPortal {
+				t.Errorf("DetectUsersPortal() type = %q, want %q", info.Type, SPATypeUsersPortal)
+			}
+			if info.ClientID != usersPortalClientID {
+				t.Errorf("DetectUsersPortal() client ID = %q, want %q", info.ClientID, usersPortalClientID)
+			}
+		})
+	}
+}
 
 func TestDetectHarbor(t *testing.T) {
 	tests := []struct {
@@ -162,7 +218,17 @@ func TestDetectOpenShift(t *testing.T) {
 }
 
 func TestDetectSPA(t *testing.T) {
-	// Test that DetectSPA tries Harbor first, then OpenShift
+	t.Run("Detects Users Portal without an API probe", func(t *testing.T) {
+		info, err := DetectSPA(http.DefaultClient, usersPortalRedirectURI,
+			[]byte(`<html><head><title>CERN Users Portal</title></head></html>`))
+		if err != nil {
+			t.Fatalf("DetectSPA() unexpected error: %v", err)
+		}
+		if info.Type != SPATypeUsersPortal {
+			t.Errorf("DetectSPA() type = %q, want %q", info.Type, SPATypeUsersPortal)
+		}
+	})
+
 	t.Run("Detects Harbor via API", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/v2.0/systeminfo" {
@@ -219,6 +285,27 @@ func TestDetectSPA(t *testing.T) {
 			t.Errorf("DetectSPA() expected error for unknown SPA, got nil")
 		}
 	})
+}
+
+func TestBuildOIDCAuthorizationURL(t *testing.T) {
+	authURL := "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/auth"
+	got, err := url.Parse(buildOIDCAuthorizationURL(authURL, usersPortalClientID, usersPortalRedirectURI))
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	if got.Scheme != "https" || got.Host != "auth.cern.ch" || got.Path != "/auth/realms/cern/protocol/openid-connect/auth" {
+		t.Errorf("authorization endpoint = %q, want %q", got.Scheme+"://"+got.Host+got.Path, authURL)
+	}
+	if got.Query().Get("client_id") != usersPortalClientID {
+		t.Errorf("client_id = %q, want %q", got.Query().Get("client_id"), usersPortalClientID)
+	}
+	if got.Query().Get("redirect_uri") != usersPortalRedirectURI {
+		t.Errorf("redirect_uri = %q, want %q", got.Query().Get("redirect_uri"), usersPortalRedirectURI)
+	}
+	if got.Query().Get("response_type") != "code" || got.Query().Get("scope") != "openid" {
+		t.Errorf("unexpected OIDC parameters: %q", got.Query())
+	}
 }
 
 func TestGetHarborLoginPage(t *testing.T) {


### PR DESCRIPTION
## Summary

- recognize the CERN Users Portal SPA (including redirects from the retired Account portal)
- start the portal's OIDC flow directly so the CLI can discover the Kerberos login link
- replace the obsolete Account portal integration coverage with Users Portal coverage

## Validation

- `make test`
- `go test -tags nowebauthn ./...`
- `make lint`
- `pre-commit run --all-files`
- `make build`
- `make build-no-webauthn`
- `make check-certs`
- `go test -tags=integration -run '^$' ./...`
- live `cookie` login to `users-portal.web.cern.ch` with a Kerberos credential cache

Fixes #140
